### PR TITLE
feat: Add comprehensive pin seeding script for manual testing

### DIFF
--- a/.agent-os/specs/2025-07-25-pin-list-view/tasks.md
+++ b/.agent-os/specs/2025-07-25-pin-list-view/tasks.md
@@ -52,11 +52,11 @@ These are the tasks to be completed for the spec detailed in @.agent-os/specs/20
   - [x] 5.5 Test responsive behavior on different screens
   - [x] 5.6 Verify all tests pass including accessibility
 
-- [ ] 6. Create seeding script for manual testing
+- [x] 6. Create seeding script for manual testing
 
-  - [ ] 6.1 Write script to create sample pins for an existing user
-  - [ ] 6.2 Generate diverse pin data (various URLs, titles, descriptions, tags)
-  - [ ] 6.3 Create enough pins to test pagination (30+ pins)
-  - [ ] 6.4 Include pins with different states (readLater true/false)
-  - [ ] 6.5 Add variety in tag usage for realistic testing
-  - [ ] 6.6 Verify seeding script works and data displays correctly
+  - [x] 6.1 Write script to create sample pins for an existing user
+  - [x] 6.2 Generate diverse pin data (various URLs, titles, descriptions, tags)
+  - [x] 6.3 Create enough pins to test pagination (30+ pins)
+  - [x] 6.4 Include pins with different states (readLater true/false)
+  - [x] 6.5 Add variety in tag usage for realistic testing
+  - [x] 6.6 Verify seeding script works and data displays correctly

--- a/libs/database/eslint.config.js
+++ b/libs/database/eslint.config.js
@@ -24,6 +24,12 @@ export default tseslint.config(
     }
   },
   {
+    files: ['src/scripts/**/*.ts'],
+    rules: {
+      'no-console': 'off'
+    }
+  },
+  {
     ignores: ['dist/**', 'node_modules/**', '**/*.js', 'drizzle/**']
   }
 )

--- a/libs/database/package.json
+++ b/libs/database/package.json
@@ -24,11 +24,14 @@
     "test:coverage": "vitest --run --coverage",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
-    "db:studio": "drizzle-kit studio"
+    "db:studio": "drizzle-kit studio",
+    "seed:pins": "tsx src/scripts/seed-pins.ts"
   },
   "dependencies": {
     "@pinsquirrel/core": "workspace:*",
+    "dotenv": "^17.2.1",
     "drizzle-orm": "^0.37.0",
+    "drizzle-seed": "^0.3.1",
     "pg": "^8.13.1"
   },
   "devDependencies": {
@@ -40,6 +43,7 @@
     "eslint": "^9.30.1",
     "pg-mem": "^3.0.5",
     "prettier": "^3.6.2",
+    "tsx": "^4.20.3",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.35.1",
     "vitest": "^3.2.4"

--- a/libs/database/src/scripts/seed-pins.ts
+++ b/libs/database/src/scripts/seed-pins.ts
@@ -1,0 +1,212 @@
+#!/usr/bin/env tsx
+
+import 'dotenv/config'
+import { seed } from 'drizzle-seed'
+import { eq, and } from 'drizzle-orm'
+import { db } from '../client.js'
+import { pins, tags, pinsTags } from '../schema/index.js'
+import { DrizzleUserRepository } from '../repositories/user-repository.js'
+
+interface SeedOptions {
+  pinCount?: number
+  tagCount?: number
+  resetDatabase?: boolean
+  seedValue?: number
+}
+
+async function seedPins(options: SeedOptions = {}) {
+  const {
+    pinCount = 35,
+    tagCount = 20,
+    resetDatabase = false,
+    seedValue = 42
+  } = options
+
+  console.log('🌱 Starting database seeding with drizzle-seed...')
+  console.log(`📊 Configuration:`)
+  console.log(`   - Pin count: ${pinCount}`)
+  console.log(`   - Tag count: ${tagCount}`)
+  console.log(`   - Reset database: ${resetDatabase}`)
+  console.log(`   - Seed value: ${seedValue}`)
+
+  try {
+    // Check for existing users
+    const userRepository = new DrizzleUserRepository(db)
+    const existingUsers = await userRepository.findAll()
+
+    if (existingUsers.length === 0) {
+      console.log(`❌ No users found in database.`)
+      console.log(`\n💡 To use this seeding script:`)
+      console.log(`   1. Register a user through the web app`)
+      console.log(`   2. Then run: pnpm --filter @pinsquirrel/database seed:pins`)
+      console.log(`\n   This will create realistic test data for all existing users.`)
+      process.exit(1)
+    }
+
+    console.log(`👥 Found ${existingUsers.length} user(s) in database`)
+
+    if (resetDatabase) {
+      console.log('🗑️ Resetting database...')
+      // Delete in order to respect foreign key constraints
+      await db.delete(pinsTags)
+      await db.delete(pins)
+      await db.delete(tags)
+      console.log('✅ Database reset complete')
+    }
+
+    // Use drizzle-seed to generate realistic data
+    console.log('🎲 Generating realistic test data...')
+    
+    // First, generate tags and pins separately
+    await seed(db, { tags, pins }, { seed: seedValue }).refine((funcs) => ({
+      tags: {
+        count: tagCount,
+        columns: {
+          name: funcs.valuesFromArray({
+            values: [
+              'react', 'javascript', 'typescript', 'node', 'css', 'html',
+              'frontend', 'backend', 'fullstack', 'api', 'database', 'sql',
+              'docker', 'git', 'github', 'testing', 'performance', 'security',
+              'design', 'ui', 'ux', 'documentation', 'tutorial', 'guide',
+              'framework', 'library', 'tools', 'development', 'productivity',
+              'web', 'mobile', 'desktop', 'cloud', 'devops', 'automation'
+            ],
+            isUnique: true
+          }),
+          userId: funcs.valuesFromArray({
+            values: existingUsers.map(u => u.id)
+          })
+        }
+      },
+      pins: {
+        count: pinCount,
+        columns: {
+          url: funcs.valuesFromArray({
+            values: (() => {
+              const domains = [
+                'developer.mozilla.org',
+                'stackoverflow.com',
+                'github.com',
+                'medium.com',
+                'dev.to',
+                'css-tricks.com',
+                'web.dev',
+                'freecodecamp.org',
+                'hashnode.com',
+                'codepen.io',
+                'smashingmagazine.com',
+                'alistapart.com',
+                'codrops.com',
+                'css-weekly.com',
+                'javascript.info'
+              ]
+              
+              const urls = []
+              for (let i = 0; i < pinCount * 2; i++) {
+                const domain = domains[i % domains.length]
+                const uuid = crypto.randomUUID()
+                urls.push(`https://${domain}/${uuid}`)
+              }
+              return urls
+            })()
+          }),
+          title: funcs.valuesFromArray({
+            values: Array.from({ length: 50 }, (_, i) => `Article Title ${i + 1}`)
+          }),
+          description: funcs.valuesFromArray({
+            values: Array.from({ length: 30 }, (_, i) => `This is a description for article ${i + 1}. It provides useful information about the topic.`)
+          }),
+          readLater: funcs.valuesFromArray({
+            values: [false, false, false, false, false, false, false, true, true, true]
+          }),
+          userId: funcs.valuesFromArray({
+            values: existingUsers.map(u => u.id)
+          })
+        }
+      }
+    }))
+
+    // Now create pin-tag relationships manually
+    console.log('🔗 Creating pin-tag relationships...')
+    const allPins = await db.select().from(pins)
+    const allTags = await db.select().from(tags)
+    
+    const relationships = []
+    for (const pin of allPins) {
+      // Give each pin 2-4 random tags
+      const numTags = Math.floor(Math.random() * 3) + 2 // 2-4 tags
+      const shuffledTags = [...allTags].sort(() => Math.random() - 0.5)
+      const selectedTags = shuffledTags.slice(0, numTags)
+      
+      for (const tag of selectedTags) {
+        relationships.push({
+          pinId: pin.id,
+          tagId: tag.id
+        })
+      }
+    }
+    
+    // Insert relationships in batches to avoid duplicates
+    const uniqueRelationships = relationships.filter((rel, index, self) => 
+      index === self.findIndex(r => r.pinId === rel.pinId && r.tagId === rel.tagId)
+    )
+    
+    if (uniqueRelationships.length > 0) {
+      await db.insert(pinsTags).values(uniqueRelationships)
+    }
+
+    // Get final stats
+    const stats = await Promise.all(
+      existingUsers.map(async (user) => {
+        const totalPins = await db.select().from(pins).where(eq(pins.userId, user.id))
+        const readLaterPins = await db.select().from(pins).where(and(eq(pins.userId, user.id), eq(pins.readLater, true)))
+        
+        return {
+          username: user.username,
+          total: totalPins.length,
+          readLater: readLaterPins.length
+        }
+      })
+    )
+
+    console.log(`\n🎉 Seeding complete!`)
+    console.log(`📈 Final stats:`)
+    stats.forEach(stat => {
+      console.log(`   👤 ${stat.username}: ${stat.total} pins (${stat.readLater} read later)`)
+    })
+
+    const totalTags = await db.select().from(tags)
+    console.log(`   🏷️ Tags created: ${totalTags.length}`)
+
+    process.exit(0)
+  } catch (error) {
+    console.error('❌ Seeding failed:', error)
+    process.exit(1)
+  }
+}
+
+// Parse command line arguments
+const args = process.argv.slice(2)
+const options: SeedOptions = {}
+
+args.forEach(arg => {
+  if (arg.startsWith('--pins=')) {
+    options.pinCount = parseInt(arg.split('=')[1])
+  } else if (arg.startsWith('--tags=')) {
+    options.tagCount = parseInt(arg.split('=')[1])
+  } else if (arg === '--reset') {
+    options.resetDatabase = true
+  } else if (arg.startsWith('--seed=')) {
+    options.seedValue = parseInt(arg.split('=')[1])
+  }
+})
+
+console.log(`\n💡 Usage: pnpm seed:pins [--pins=35] [--tags=20] [--reset] [--seed=42]`)
+console.log(`   --pins=N    Number of pins to generate (default: 35)`)
+console.log(`   --tags=N    Number of tags to generate (default: 20)`)
+console.log(`   --reset     Reset database before seeding`)
+console.log(`   --seed=N    Seed value for deterministic generation (default: 42)`)
+console.log(``)
+
+// Run the seeding
+seedPins(options)

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "format": "turbo format",
     "test": "turbo test",
     "db:up": "docker compose -f docker-compose.dev.yml down && docker compose -f docker-compose.dev.yml up -d postgres",
-    "db:down": "docker compose -f docker-compose.dev.yml down"
+    "db:down": "docker compose -f docker-compose.dev.yml down",
+    "seed:pins": "pnpm --filter @pinsquirrel/database seed:pins"
   },
   "devDependencies": {
     "turbo": "latest"
@@ -19,5 +20,8 @@
   "engines": {
     "node": ">=22.0.0"
   },
-  "packageManager": "pnpm@10.13.1+sha512.37ebf1a5c7a30d5fabe0c5df44ee8da4c965ca0c5af3dbab28c3a1681b70a256218d05c81c9c0dcf767ef6b8551eb5b960042b9ed4300c59242336377e01cfad"
+  "packageManager": "pnpm@10.13.1+sha512.37ebf1a5c7a30d5fabe0c5df44ee8da4c965ca0c5af3dbab28c3a1681b70a256218d05c81c9c0dcf767ef6b8551eb5b960042b9ed4300c59242336377e01cfad",
+  "dependencies": {
+    "tsx": "^4.20.3"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      tsx:
+        specifier: ^4.20.3
+        version: 4.20.3
     devDependencies:
       turbo:
         specifier: latest
@@ -169,9 +173,15 @@ importers:
       '@pinsquirrel/core':
         specifier: workspace:*
         version: link:../core
+      dotenv:
+        specifier: ^17.2.1
+        version: 17.2.1
       drizzle-orm:
         specifier: ^0.37.0
         version: 0.37.0(@types/pg@8.15.4)(@types/react@19.1.8)(pg@8.16.3)(react@19.1.0)
+      drizzle-seed:
+        specifier: ^0.3.1
+        version: 0.3.1(drizzle-orm@0.37.0(@types/pg@8.15.4)(@types/react@19.1.8)(pg@8.16.3)(react@19.1.0))
       pg:
         specifier: ^8.13.1
         version: 8.16.3
@@ -200,6 +210,9 @@ importers:
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
+      tsx:
+        specifier: ^4.20.3
+        version: 4.20.3
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -1672,6 +1685,10 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  dotenv@17.2.1:
+    resolution: {integrity: sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==}
+    engines: {node: '>=12'}
+
   drizzle-kit@0.29.1:
     resolution: {integrity: sha512-OvHL8RVyYiPR3LLRE3SHdcON8xGXl+qMfR9uTTnFWBPIqVk/3NWYZPb7nfpM1Bhix3H+BsxqPyyagG7YZ+Z63A==}
     hasBin: true
@@ -1766,6 +1783,14 @@ packages:
       sql.js:
         optional: true
       sqlite3:
+        optional: true
+
+  drizzle-seed@0.3.1:
+    resolution: {integrity: sha512-F/0lgvfOAsqlYoHM/QAGut4xXIOXoE5VoAdv2FIl7DpGYVXlAzKuJO+IphkKUFK3Dz+rFlOsQLnMNrvoQ0cx7g==}
+    peerDependencies:
+      drizzle-orm: '>=0.36.4'
+    peerDependenciesMeta:
+      drizzle-orm:
         optional: true
 
   dunder-proto@1.0.1:
@@ -2884,6 +2909,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   qs@6.13.0:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
@@ -4888,6 +4916,8 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dotenv@17.2.1: {}
+
   drizzle-kit@0.29.1:
     dependencies:
       '@drizzle-team/brocli': 0.10.2
@@ -4903,6 +4933,12 @@ snapshots:
       '@types/react': 19.1.8
       pg: 8.16.3
       react: 19.1.0
+
+  drizzle-seed@0.3.1(drizzle-orm@0.37.0(@types/pg@8.15.4)(@types/react@19.1.8)(pg@8.16.3)(react@19.1.0)):
+    dependencies:
+      pure-rand: 6.1.0
+    optionalDependencies:
+      drizzle-orm: 0.37.0(@types/pg@8.15.4)(@types/react@19.1.8)(pg@8.16.3)(react@19.1.0)
 
   dunder-proto@1.0.1:
     dependencies:
@@ -6138,6 +6174,8 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  pure-rand@6.1.0: {}
+
   qs@6.13.0:
     dependencies:
       side-channel: 1.1.0
@@ -6568,7 +6606,6 @@ snapshots:
       get-tsconfig: 4.10.1
     optionalDependencies:
       fsevents: 2.3.3
-    optional: true
 
   turbo-darwin-64@2.5.5:
     optional: true


### PR DESCRIPTION
- Install and configure drizzle-seed for realistic test data generation
- Create flexible seeding script with command-line options
- Generate unique URLs using realistic dev domains with UUID paths
- Support configurable pin count, tag count, database reset, and seed values
- Add realistic tech-related tags with unique constraints
- Include proper read-later state distribution (30% marked as read later)
- Create manual pin-tag relationships to avoid constraint violations
- Add comprehensive usage documentation and error handling
- Move seeding script to database package with proper environment setup

Usage: pnpm seed:pins [--pins=35] [--tags=20] [--reset] [--seed=42]

This provides 35+ pins for thorough pagination testing and realistic content variety for manual testing of the pin list view interface.

🤖 Generated with [Claude Code](https://claude.ai/code)