### PR TITLE
feat: Implement pin list improvements and clickable links

### DIFF
--- a/apps/web/app/components/pins/PinCard.test.tsx
+++ b/apps/web/app/components/pins/PinCard.test.tsx
@@ -26,18 +26,15 @@ describe('PinCard', () => {
     expect(screen.getByText('Example Pin')).toBeInTheDocument()
   })
 
-  it('displays URL with proper formatting', () => {
+  it('displays full URL', () => {
     render(<PinCard pin={mockPin} />)
-    expect(screen.getByText('example.com')).toBeInTheDocument()
+    expect(screen.getByText('https://example.com')).toBeInTheDocument()
   })
 
-  it('displays truncated description with ellipsis for long text', () => {
-    const longDescription = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
-    const pinWithLongDesc = { ...mockPin, description: longDescription }
-    
-    render(<PinCard pin={pinWithLongDesc} />)
+  it('displays description when present', () => {
+    render(<PinCard pin={mockPin} />)
     const description = screen.getByTestId('pin-description')
-    expect(description).toHaveClass('line-clamp-3')
+    expect(description).toHaveTextContent('This is a test pin description')
   })
 
   it('shows all associated tags as badges', () => {
@@ -46,10 +43,10 @@ describe('PinCard', () => {
     expect(screen.getByText('react')).toBeInTheDocument()
   })
 
-  it('shows placeholder when no description provided', () => {
+  it('hides description when not provided', () => {
     const pinWithoutDesc = { ...mockPin, description: null }
     render(<PinCard pin={pinWithoutDesc} />)
-    expect(screen.getByText('No description')).toBeInTheDocument()
+    expect(screen.queryByTestId('pin-description')).not.toBeInTheDocument()
   })
 
   it('renders action buttons appropriately', () => {
@@ -61,7 +58,7 @@ describe('PinCard', () => {
   it('handles pins with no tags', () => {
     const pinWithoutTags = { ...mockPin, tags: [] }
     render(<PinCard pin={pinWithoutTags} />)
-    expect(screen.queryByTestId('pin-tags')).toBeEmptyDOMElement()
+    expect(screen.queryByTestId('pin-tags')).not.toBeInTheDocument()
   })
 
   it('handles invalid URLs gracefully', () => {
@@ -70,24 +67,36 @@ describe('PinCard', () => {
     expect(screen.getByText('not-a-valid-url')).toBeInTheDocument()
   })
 
-  it('removes www from domain display', () => {
+  it('displays full URL including www and path', () => {
     const pinWithWww = { ...mockPin, url: 'https://www.example.com/path' }
     render(<PinCard pin={pinWithWww} />)
-    expect(screen.getByText('example.com')).toBeInTheDocument()
+    expect(screen.getByText('https://www.example.com/path')).toBeInTheDocument()
   })
 
   it('handles empty description with null value', () => {
     const pinWithNullDesc = { ...mockPin, description: null }
     render(<PinCard pin={pinWithNullDesc} />)
-    expect(screen.getByText('No description')).toBeInTheDocument()
+    expect(screen.queryByTestId('pin-description')).not.toBeInTheDocument()
   })
 
-  it('renders action buttons with proper accessibility', () => {
+  it('renders action buttons as text links with proper accessibility', () => {
     render(<PinCard pin={mockPin} />)
     const editButton = screen.getByLabelText('Edit Example Pin')
     const deleteButton = screen.getByLabelText('Delete Example Pin')
     
-    expect(editButton).toHaveClass('h-8', 'w-8')
-    expect(deleteButton).toHaveClass('h-8', 'w-8')
+    expect(editButton).toHaveTextContent('edit')
+    expect(deleteButton).toHaveTextContent('delete')
+    expect(editButton).toHaveClass('text-xs', 'text-blue-600')
+    expect(deleteButton).toHaveClass('text-xs', 'text-blue-600')
+  })
+
+  it('displays relative time correctly', () => {
+    // Create a pin from 2 days ago
+    const twoDaysAgo = new Date()
+    twoDaysAgo.setDate(twoDaysAgo.getDate() - 2)
+    const pinWithOldDate = { ...mockPin, createdAt: twoDaysAgo }
+    
+    render(<PinCard pin={pinWithOldDate} />)
+    expect(screen.getByText('2 days ago')).toBeInTheDocument()
   })
 })

--- a/apps/web/app/components/pins/PinCard.tsx
+++ b/apps/web/app/components/pins/PinCard.tsx
@@ -1,94 +1,119 @@
 import type { Pin } from '@pinsquirrel/core'
-import { Edit, Trash2 } from 'lucide-react'
-import { Button } from '~/components/ui/button'
-import { Card, CardContent } from '~/components/ui/card'
 
 interface PinCardProps {
   pin: Pin
 }
 
 export function PinCard({ pin }: PinCardProps) {
-  // Extract domain from URL
-  const getDomain = (url: string) => {
-    try {
-      const { hostname } = new URL(url)
-      return hostname.replace('www.', '')
-    } catch {
-      return url
-    }
+  // Format relative time (simplified for now)
+  const getRelativeTime = (date: Date) => {
+    const now = new Date()
+    const diffInHours = Math.floor((now.getTime() - date.getTime()) / (1000 * 60 * 60))
+    const diffInDays = Math.floor(diffInHours / 24)
+    
+    if (diffInHours < 1) return 'just now'
+    if (diffInHours < 24) return `${diffInHours} hour${diffInHours > 1 ? 's' : ''} ago`
+    if (diffInDays === 1) return 'yesterday'
+    if (diffInDays < 7) return `${diffInDays} days ago`
+    if (diffInDays < 30) return `${Math.floor(diffInDays / 7)} week${Math.floor(diffInDays / 7) > 1 ? 's' : ''} ago`
+    return `${Math.floor(diffInDays / 30)} month${Math.floor(diffInDays / 30) > 1 ? 's' : ''} ago`
   }
 
   return (
-    <Card className="group relative" role="article" aria-labelledby={`pin-title-${pin.id}`}>
-      <CardContent className="p-6">
-        <div className="flex justify-between items-start gap-4">
-          <div className="flex-1 min-w-0">
-            {/* Title */}
-            <h3 
-              id={`pin-title-${pin.id}`}
-              className="text-lg font-medium mb-1 truncate"
-            >
-              {pin.title}
-            </h3>
+    <div 
+      className="py-1"
+      role="article" 
+      aria-labelledby={`pin-title-${pin.id}`}
+    >
+      {/* Main content */}
+      <div className="flex-1 min-w-0">
+        {/* Title as link */}
+        <h3 
+          id={`pin-title-${pin.id}`}
+          className="mb-0.5"
+        >
+          <a
+            href={pin.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 hover:text-blue-800 font-normal"
+          >
+            {pin.title}
+          </a>
+        </h3>
 
-            {/* URL */}
-            <p className="text-sm text-muted-foreground mb-3" aria-label="Website domain">
-              {getDomain(pin.url)}
-            </p>
+        {/* URL as link */}
+        <div className="text-xs mb-1">
+          <a
+            href={pin.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-muted-foreground hover:text-blue-600"
+          >
+            {pin.url}
+          </a>
+        </div>
 
-            {/* Description */}
-            <p
-              data-testid="pin-description"
-              className="text-sm text-muted-foreground line-clamp-3 mb-4"
-              aria-label={pin.description ? "Pin description" : "No description available"}
-            >
-              {pin.description || 'No description'}
-            </p>
-
-            {/* Tags */}
-            <div 
-              className="flex flex-wrap gap-2" 
-              data-testid="pin-tags"
-              role="list"
-              aria-label={pin.tags.length > 0 ? `Tags: ${pin.tags.map(t => t.name).join(', ')}` : "No tags"}
-            >
-              {pin.tags.map((tag) => (
-                <span
-                  key={tag.id}
-                  className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-primary/10 text-primary"
-                  role="listitem"
-                >
-                  {tag.name}
-                </span>
-              ))}
-            </div>
+        {/* Description (if exists) */}
+        {pin.description && (
+          <div 
+            data-testid="pin-description"
+            className="text-xs text-muted-foreground mb-1"
+          >
+            {pin.description}
           </div>
+        )}
+
+        {/* Tags */}
+        {pin.tags.length > 0 && (
+          <div 
+            className="flex flex-wrap gap-1 mb-1" 
+            data-testid="pin-tags"
+            role="list"
+            aria-label={`Tags: ${pin.tags.map(t => t.name).join(', ')}`}
+          >
+            {pin.tags.map((tag) => (
+              <span
+                key={tag.id}
+                className="text-xs text-orange-600 hover:text-orange-800 cursor-pointer"
+                role="listitem"
+              >
+                {tag.name}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* Bottom row: Timestamp and Actions */}
+        <div 
+          className="flex items-center gap-2 text-xs text-muted-foreground"
+        >
+          {/* Timestamp */}
+          <span>
+            {getRelativeTime(pin.createdAt)}
+          </span>
 
           {/* Actions */}
           <div 
-            className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity"
+            className="flex gap-2"
             role="group"
             aria-label={`Actions for ${pin.title}`}
           >
-            <Button
-              size="icon"
-              variant="ghost"
+            <button
+              className="text-xs text-blue-600 hover:text-blue-800 cursor-pointer"
               aria-label={`Edit ${pin.title}`}
-              className="h-8 w-8"
             >
-              <Edit className="h-4 w-4" aria-hidden="true" />
-            </Button>
-            <Button
-              size="icon"
-              variant="ghost"
+              edit
+            </button>
+            <button
+              className="text-xs text-blue-600 hover:text-blue-800 cursor-pointer"
               aria-label={`Delete ${pin.title}`}
-              className="h-8 w-8"
             >
-              <Trash2 className="h-4 w-4" aria-hidden="true" />
-            </Button>
+              delete
+            </button>
           </div>
         </div>
-      </CardContent>
-    </Card>
+      </div>
+    </div>
   )
 }

--- a/apps/web/app/components/pins/PinList.test.tsx
+++ b/apps/web/app/components/pins/PinList.test.tsx
@@ -73,17 +73,17 @@ describe('PinList', () => {
     render(<PinList pins={[]} isLoading={false} />)
     
     expect(screen.getByTestId('empty-state')).toBeInTheDocument()
-    expect(screen.queryByTestId('pin-list-grid')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('pin-list')).not.toBeInTheDocument()
   })
 
-  it('renders pin cards in grid layout when pins provided', () => {
+  it('renders pin cards in list layout when pins provided', () => {
     render(<PinList pins={mockPins} isLoading={false} />)
     
     // Should not show empty state
     expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument()
     
-    // Should show grid container
-    expect(screen.getByTestId('pin-list-grid')).toBeInTheDocument()
+    // Should show list container
+    expect(screen.getByTestId('pin-list')).toBeInTheDocument()
     
     // Should render all pin cards
     expect(screen.getByTestId('pin-card-pin-1')).toBeInTheDocument()
@@ -96,18 +96,18 @@ describe('PinList', () => {
     expect(screen.getByText('Mock PinCard: Third Pin')).toBeInTheDocument()
   })
 
-  it('applies correct CSS classes for responsive grid layout', () => {
+  it('applies correct CSS classes for vertical list layout', () => {
     render(<PinList pins={mockPins} isLoading={false} />)
     
-    const gridContainer = screen.getByTestId('pin-list-grid')
-    expect(gridContainer).toHaveClass('grid', 'gap-4', 'md:grid-cols-2', 'lg:grid-cols-3')
+    const listContainer = screen.getByTestId('pin-list')
+    expect(listContainer).toHaveClass('space-y-4')
   })
 
   it('shows loading state when isLoading is true', () => {
     render(<PinList pins={mockPins} isLoading={true} />)
     
     expect(screen.getByTestId('pin-list-loading')).toBeInTheDocument()
-    expect(screen.queryByTestId('pin-list-grid')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('pin-list')).not.toBeInTheDocument()
     expect(screen.queryByTestId('empty-state')).not.toBeInTheDocument()
   })
 
@@ -127,7 +127,7 @@ describe('PinList', () => {
     render(<PinList pins={mockPins} isLoading={true} />)
     
     expect(screen.getByTestId('pin-list-loading')).toBeInTheDocument()
-    expect(screen.queryByTestId('pin-list-grid')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('pin-list')).not.toBeInTheDocument()
     expect(screen.queryByTestId('pin-card-pin-1')).not.toBeInTheDocument()
   })
 
@@ -135,18 +135,18 @@ describe('PinList', () => {
     const singlePin = [mockPins[0]]
     render(<PinList pins={singlePin} isLoading={false} />)
     
-    expect(screen.getByTestId('pin-list-grid')).toBeInTheDocument()
+    expect(screen.getByTestId('pin-list')).toBeInTheDocument()
     expect(screen.getByTestId('pin-card-pin-1')).toBeInTheDocument()
     expect(screen.queryByTestId('pin-card-pin-2')).not.toBeInTheDocument()
   })
 
-  it('maintains grid layout with different numbers of pins', () => {
-    // Test with 2 pins (should still use grid layout)
+  it('maintains list layout with different numbers of pins', () => {
+    // Test with 2 pins (should use vertical list layout)
     const twoPins = mockPins.slice(0, 2)
     render(<PinList pins={twoPins} isLoading={false} />)
     
-    const gridContainer = screen.getByTestId('pin-list-grid')
-    expect(gridContainer).toHaveClass('grid', 'gap-4', 'md:grid-cols-2', 'lg:grid-cols-3')
+    const listContainer = screen.getByTestId('pin-list')
+    expect(listContainer).toHaveClass('space-y-4')
     expect(screen.getByTestId('pin-card-pin-1')).toBeInTheDocument()
     expect(screen.getByTestId('pin-card-pin-2')).toBeInTheDocument()
   })

--- a/apps/web/app/components/pins/PinList.tsx
+++ b/apps/web/app/components/pins/PinList.tsx
@@ -11,31 +11,29 @@ function PinSkeleton({ index }: { index: number }) {
   return (
     <div 
       data-testid={`pin-skeleton-${index}`}
-      className="bg-card rounded-lg border p-4 animate-pulse"
+      className="py-1 animate-pulse"
       role="status"
       aria-label={`Loading pin ${index + 1}`}
     >
-      <div className="space-y-3">
+      <div className="flex-1 min-w-0 space-y-1">
         {/* Title skeleton */}
         <div className="h-4 bg-muted rounded w-3/4" aria-hidden="true"></div>
         
         {/* URL skeleton */}
-        <div className="h-3 bg-muted rounded w-1/2" aria-hidden="true"></div>
-        
-        {/* Description skeleton */}
-        <div className="space-y-2">
-          <div className="h-3 bg-muted rounded" aria-hidden="true"></div>
-          <div className="h-3 bg-muted rounded w-5/6" aria-hidden="true"></div>
-        </div>
+        <div className="h-3 bg-muted rounded w-2/3" aria-hidden="true"></div>
         
         {/* Tags skeleton */}
-        <div className="flex gap-2">
-          <div className="h-6 bg-muted rounded-full w-16" aria-hidden="true"></div>
-          <div className="h-6 bg-muted rounded-full w-20" aria-hidden="true"></div>
+        <div className="flex gap-1">
+          <div className="h-3 bg-muted rounded w-12" aria-hidden="true"></div>
+          <div className="h-3 bg-muted rounded w-16" aria-hidden="true"></div>
         </div>
-        
-        {/* Date skeleton */}
-        <div className="h-3 bg-muted rounded w-1/3" aria-hidden="true"></div>
+
+        {/* Bottom row skeleton - timestamp and actions */}
+        <div className="flex items-center gap-2">
+          <div className="h-3 bg-muted rounded w-16" aria-hidden="true"></div>
+          <div className="h-3 bg-muted rounded w-8" aria-hidden="true"></div>
+          <div className="h-3 bg-muted rounded w-12" aria-hidden="true"></div>
+        </div>
       </div>
       <span className="sr-only">Loading pin content...</span>
     </div>
@@ -52,7 +50,7 @@ export function PinList({ pins, isLoading }: PinListProps) {
         aria-live="polite"
         aria-label="Loading pins"
       >
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        <div className="space-y-4">
           {Array.from({ length: 6 }, (_, index) => (
             <PinSkeleton key={index} index={index} />
           ))}
@@ -67,11 +65,11 @@ export function PinList({ pins, isLoading }: PinListProps) {
     return <EmptyState />
   }
 
-  // Show pins in responsive grid
+  // Show pins in vertical list
   return (
     <div 
-      data-testid="pin-list-grid"
-      className="grid gap-4 md:grid-cols-2 lg:grid-cols-3"
+      data-testid="pin-list"
+      className="space-y-4"
       role="region"
       aria-label={`${pins.length} pins`}
     >

--- a/apps/web/app/components/pins/accessibility.test.tsx
+++ b/apps/web/app/components/pins/accessibility.test.tsx
@@ -45,6 +45,16 @@ describe('Pin List Accessibility', () => {
       const user = userEvent.setup()
       render(<PinCard pin={mockPin} />)
 
+      // Tab to title link
+      await user.tab()
+      const titleLink = screen.getByRole('link', { name: 'Test Article' })
+      expect(titleLink).toHaveFocus()
+
+      // Tab to URL link
+      await user.tab()
+      const urlLink = screen.getByRole('link', { name: 'https://example.com/article' })
+      expect(urlLink).toHaveFocus()
+
       // Tab to first action button (Edit)
       await user.tab()
       const editButton = screen.getByLabelText('Edit Test Article')
@@ -60,12 +70,16 @@ describe('Pin List Accessibility', () => {
       const user = userEvent.setup()
       render(<PinCard pin={mockPin} />)
 
-      // Tab to edit button and activate with Enter
+      // Tab to title link
+      await user.tab()
+      // Tab to URL link
+      await user.tab()
+      // Tab to edit button and verify focus
       await user.tab()
       const editButton = screen.getByLabelText('Edit Test Article')
       expect(editButton).toHaveFocus()
 
-      // Tab to delete button and activate with Space
+      // Tab to delete button and verify focus
       await user.tab()
       const deleteButton = screen.getByLabelText('Delete Test Article')
       expect(deleteButton).toHaveFocus()
@@ -190,7 +204,14 @@ describe('Pin List Accessibility', () => {
       const user = userEvent.setup()
       render(<PinList pins={mockPins} isLoading={false} />)
 
-      // Should be able to tab through all pin action buttons
+      // Tab through first pin's elements: title link, URL link, edit button, delete button
+      await user.tab()
+      const titleLinks = screen.getAllByRole('link', { name: /Pin/ })
+      expect(titleLinks[0]).toHaveFocus() // First pin's title link
+
+      await user.tab()
+      // Should focus URL link of first pin
+      
       await user.tab()
       const editButtons = screen.getAllByLabelText(/Edit/)
       expect(editButtons[0]).toHaveFocus()
@@ -200,8 +221,8 @@ describe('Pin List Accessibility', () => {
       expect(deleteButtons[0]).toHaveFocus()
 
       await user.tab()
-      // Should move to next pin's edit button
-      expect(editButtons[1]).toHaveFocus()
+      // Should move to second pin's title link
+      expect(titleLinks[1]).toHaveFocus()
     })
 
     it('has proper heading hierarchy', () => {
@@ -214,18 +235,18 @@ describe('Pin List Accessibility', () => {
       expect(headings[2]).toHaveTextContent('Third Pin')
     })
 
-    it('maintains proper focus order in grid layout', async () => {
+    it('maintains proper focus order in list layout', async () => {
       const user = userEvent.setup()
       render(<PinList pins={mockPins} isLoading={false} />)
 
-      // Grid should maintain logical tab order
-      const gridContainer = screen.getByTestId('pin-list-grid')
-      expect(gridContainer).toHaveClass('grid')
+      // List should maintain logical tab order
+      const listContainer = screen.getByTestId('pin-list')
+      expect(listContainer).toHaveClass('space-y-4')
 
-      // First tab should go to first pin's first button
+      // First tab should go to first pin's title link
       await user.tab()
-      const firstEditButton = screen.getAllByLabelText(/Edit/)[0]
-      expect(firstEditButton).toHaveFocus()
+      const titleLinks = screen.getAllByRole('link', { name: /Pin/ })
+      expect(titleLinks[0]).toHaveFocus()
     })
 
     it('handles empty state accessibility', () => {
@@ -267,9 +288,9 @@ describe('Pin List Accessibility', () => {
     it('respects reduced motion preferences for animations', () => {
       render(<PinCard pin={mockPin} />)
 
-      // Action buttons should have transition classes
+      // Action buttons should be always visible (no transition needed)
       const actionsContainer = screen.getByLabelText('Edit Test Article').parentElement
-      expect(actionsContainer).toHaveClass('transition-opacity')
+      expect(actionsContainer).toHaveClass('flex', 'gap-2')
     })
   })
 
@@ -321,8 +342,8 @@ describe('Pin List Accessibility', () => {
       const description = screen.getByTestId('pin-description')
       expect(description).toHaveTextContent('A test article description')
 
-      // Domain should be clear
-      expect(screen.getByText('example.com')).toBeInTheDocument()
+      // URL should be clear
+      expect(screen.getByText('https://example.com/article')).toBeInTheDocument()
     })
   })
 
@@ -349,7 +370,7 @@ describe('Pin List Accessibility', () => {
       expect(mobileNav).toHaveClass('flex', 'sm:hidden')
     })
 
-    it('maintains proper grid responsiveness in pin list', () => {
+    it('maintains proper vertical layout in pin list', () => {
       const mockPins = [
         { ...mockPin, id: 'pin-1', title: 'First Pin' },
         { ...mockPin, id: 'pin-2', title: 'Second Pin' }
@@ -357,10 +378,10 @@ describe('Pin List Accessibility', () => {
 
       render(<PinList pins={mockPins} isLoading={false} />)
 
-      const gridContainer = screen.getByTestId('pin-list-grid')
+      const listContainer = screen.getByTestId('pin-list')
       
-      // Check responsive grid classes
-      expect(gridContainer).toHaveClass('grid', 'gap-4', 'md:grid-cols-2', 'lg:grid-cols-3')
+      // Check vertical list classes
+      expect(listContainer).toHaveClass('space-y-4')
     })
 
     it('ensures pin cards adapt to different screen sizes', () => {
@@ -368,11 +389,11 @@ describe('Pin List Accessibility', () => {
 
       // Pin card should be flexible and adapt to parent container
       const card = screen.getByRole('article')
-      expect(card).toHaveClass('group', 'relative')
+      expect(card).toHaveClass('py-1')
 
-      // Content should have proper responsive spacing
-      const content = card.querySelector('[data-slot="card-content"]')
-      expect(content).toHaveClass('p-6')
+      // Content should have proper compact spacing
+      const content = card.querySelector('.flex-1')
+      expect(content).toHaveClass('flex-1', 'min-w-0')
     })
 
     it('provides accessible navigation on all screen sizes', () => {

--- a/apps/web/app/routes/home.tsx
+++ b/apps/web/app/routes/home.tsx
@@ -1,10 +1,17 @@
-import { Link, useLoaderData, Form } from 'react-router'
+import { Link, redirect } from 'react-router'
 import type { Route } from './+types/home'
 import { getUser } from '~/lib/session.server'
 import { Button } from '~/components/ui/button'
 
 export async function loader({ request }: Route.LoaderArgs) {
   const user = await getUser(request)
+  
+  // Redirect logged-in users to pins page
+  if (user) {
+    // eslint-disable-next-line @typescript-eslint/only-throw-error
+    throw redirect('/pins')
+  }
+  
   return { user }
 }
 
@@ -16,7 +23,7 @@ export function meta(_: Route.MetaArgs) {
 }
 
 export default function Home() {
-  const { user } = useLoaderData<typeof loader>()
+  // No need to access user data since logged-in users are redirected
 
   return (
     <div className="min-h-screen bg-background">
@@ -41,30 +48,13 @@ export default function Home() {
 
           {/* Call to Action */}
           <div className="flex flex-col sm:flex-row gap-4 justify-center items-center mb-20">
-            {user ? (
-              // Logged in state
-              <div className="flex flex-col sm:flex-row gap-4 items-center">
-                <p className="text-foreground">
-                  Welcome back,{' '}
-                  <span className="font-medium">{user.username}</span>
-                </p>
-                <Form method="post" action="/logout">
-                  <Button variant="outline" type="submit">
-                    Logout
-                  </Button>
-                </Form>
-              </div>
-            ) : (
-              // Logged out state
-              <>
-                <Button asChild>
-                  <Link to="/register">Get Started</Link>
-                </Button>
-                <Button variant="outline" asChild>
-                  <Link to="/login">Sign In</Link>
-                </Button>
-              </>
-            )}
+            {/* Since logged-in users are redirected, we only show logged out state */}
+            <Button asChild>
+              <Link to="/register">Get Started</Link>
+            </Button>
+            <Button variant="outline" asChild>
+              <Link to="/login">Sign In</Link>
+            </Button>
           </div>
 
           {/* Features */}

--- a/apps/web/app/routes/pins.integration.test.tsx
+++ b/apps/web/app/routes/pins.integration.test.tsx
@@ -142,11 +142,11 @@ describe('PinsPage Integration', () => {
     
     expect(screen.getByText('Example Pin')).toBeInTheDocument()
     expect(screen.getByText('Another Pin')).toBeInTheDocument()
-    expect(screen.getByText('example.com')).toBeInTheDocument()
-    expect(screen.getByText('example2.com')).toBeInTheDocument()
+    expect(screen.getByText('https://example.com')).toBeInTheDocument()
+    expect(screen.getByText('https://example2.com')).toBeInTheDocument()
   })
 
-  it('renders pins in responsive grid layout', () => {
+  it('renders pins in vertical list layout', () => {
     mockUseLoaderData.mockReturnValue({
       pins: mockPins,
       totalPages: 1,
@@ -156,9 +156,9 @@ describe('PinsPage Integration', () => {
 
     render(<PinsPage />)
     
-    // Check that the grid container has the correct classes
-    const gridContainer = screen.getByTestId('pin-list-grid')
-    expect(gridContainer).toHaveClass('grid', 'gap-4', 'md:grid-cols-2', 'lg:grid-cols-3')
+    // Check that the list container has the correct classes
+    const listContainer = screen.getByTestId('pin-list')
+    expect(listContainer).toHaveClass('space-y-4')
   })
 
   it('shows loading state when navigation state is loading', () => {
@@ -175,7 +175,7 @@ describe('PinsPage Integration', () => {
     
     // Should show loading skeleton instead of actual pins
     expect(screen.getByTestId('pin-list-loading')).toBeInTheDocument()
-    expect(screen.queryByTestId('pin-list-grid')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('pin-list')).not.toBeInTheDocument()
     expect(screen.queryByText('Example Pin')).not.toBeInTheDocument()
   })
 
@@ -192,10 +192,10 @@ describe('PinsPage Integration', () => {
     // Check main container structure - need to go up one more level
     const headerContainer = screen.getByText('My Pins').closest('div')  // mb-8 div
     const mainContainer = headerContainer?.parentElement  // max-w-7xl mx-auto div
-    expect(mainContainer).toHaveClass('max-w-7xl', 'mx-auto')
+    expect(mainContainer).toHaveClass('max-w-7xl', 'mx-auto', 'px-4', 'sm:px-6', 'lg:px-8')
     
     const pageContainer = mainContainer?.parentElement
-    expect(pageContainer).toHaveClass('min-h-screen', 'bg-background', 'py-12', 'px-4', 'sm:px-6', 'lg:px-8')
+    expect(pageContainer).toHaveClass('min-h-screen', 'bg-background', 'py-12')
   })
 
   it('shows correct header spacing and typography', () => {
@@ -233,8 +233,8 @@ describe('PinsPage Integration', () => {
     expect(screen.getByText('Example Pin')).toBeInTheDocument()
     expect(screen.queryByText("You don't have any pins yet")).not.toBeInTheDocument()
     
-    // Verify grid layout is used
-    expect(screen.getByTestId('pin-list-grid')).toBeInTheDocument()
+    // Verify list layout is used
+    expect(screen.getByTestId('pin-list')).toBeInTheDocument()
   })
 
   it('handles navigation state changes correctly', () => {
@@ -251,7 +251,7 @@ describe('PinsPage Integration', () => {
     const { rerender } = render(<PinsPage />)
     
     // Should show actual content
-    expect(screen.getByTestId('pin-list-grid')).toBeInTheDocument()
+    expect(screen.getByTestId('pin-list')).toBeInTheDocument()
     expect(screen.getByText('Example Pin')).toBeInTheDocument()
 
     // Change to loading state
@@ -261,6 +261,6 @@ describe('PinsPage Integration', () => {
     
     // Should show loading state
     expect(screen.getByTestId('pin-list-loading')).toBeInTheDocument()
-    expect(screen.queryByTestId('pin-list-grid')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('pin-list')).not.toBeInTheDocument()
   })
 })

--- a/apps/web/app/routes/pins.tsx
+++ b/apps/web/app/routes/pins.tsx
@@ -44,8 +44,8 @@ export default function PinsPage() {
   const isLoading = navigation.state === 'loading'
 
   return (
-    <div className="min-h-screen bg-background py-12 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-7xl mx-auto">
+    <div className="min-h-screen bg-background py-12">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-foreground">My Pins</h1>
           <p className="mt-2 text-muted-foreground">

--- a/libs/database/src/repositories/pin-repository.ts
+++ b/libs/database/src/repositories/pin-repository.ts
@@ -1,4 +1,4 @@
-import { eq, and, count } from 'drizzle-orm'
+import { eq, and, count, desc } from 'drizzle-orm'
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js'
 import type {
   Pin,
@@ -37,7 +37,7 @@ export class DrizzlePinRepository implements PinRepository {
       .select()
       .from(pins)
       .where(eq(pins.userId, userId))
-      .orderBy(pins.createdAt)
+      .orderBy(desc(pins.createdAt))
 
     let query
     if (options?.limit !== undefined && options?.offset !== undefined) {
@@ -77,6 +77,7 @@ export class DrizzlePinRepository implements PinRepository {
       .from(pins)
       .innerJoin(pinsTags, eq(pins.id, pinsTags.pinId))
       .where(and(eq(pins.userId, userId), eq(pinsTags.tagId, tagId)))
+      .orderBy(desc(pins.createdAt))
 
     const uniquePins = Array.from(
       new Map(result.map(r => [r.pin.id, r.pin])).values()
@@ -98,6 +99,7 @@ export class DrizzlePinRepository implements PinRepository {
       .select()
       .from(pins)
       .where(and(eq(pins.userId, userId), eq(pins.readLater, readLater)))
+      .orderBy(desc(pins.createdAt))
 
     return Promise.all(
       result.map(async pin => {
@@ -125,7 +127,7 @@ export class DrizzlePinRepository implements PinRepository {
   }
 
   async findAll(): Promise<Pin[]> {
-    const result = await this.db.select().from(pins)
+    const result = await this.db.select().from(pins).orderBy(desc(pins.createdAt))
 
     return Promise.all(
       result.map(async pin => {
@@ -136,7 +138,7 @@ export class DrizzlePinRepository implements PinRepository {
   }
 
   async list(limit?: number, offset?: number): Promise<Pin[]> {
-    const baseQuery = this.db.select().from(pins)
+    const baseQuery = this.db.select().from(pins).orderBy(desc(pins.createdAt))
 
     let query
     if (limit !== undefined && offset !== undefined) {


### PR DESCRIPTION
- Transform pin layout from multi-column grid to single-column list view
- Redesign pin cards with Pinboard-inspired compact layout
- Sort pins by creation date in descending order (newest first)
- Make pin titles and URLs clickable external links
- Redirect logged-in users from home page to pins page
- Update all tests for new layout and functionality
- Maintain full accessibility support with updated focus order

🤖 Generated with [Claude Code](https://claude.ai/code)