### PR TITLE
feat: implement pin creation form with validation

### DIFF
--- a/.agent-os/specs/2025-08-05-pin-creation-form/tasks.md
+++ b/.agent-os/specs/2025-08-05-pin-creation-form/tasks.md
@@ -7,13 +7,13 @@ These are the tasks to be completed for the spec detailed in @.agent-os/specs/20
 
 ## Tasks
 
-- [ ] 1. Create form components and validation
-  - [ ] 1.1 Write tests for PinCreationForm component
-  - [ ] 1.2 Implement PinCreationForm with React Hook Form
-  - [ ] 1.3 Write tests for form validation schema
-  - [ ] 1.4 Implement zod validation for URL, title, description
-  - [ ] 1.5 Add form field components using shadcn/ui
-  - [ ] 1.6 Verify all component tests pass
+- [x] 1. Create form components and validation
+  - [x] 1.1 Write tests for PinCreationForm component
+  - [x] 1.2 Implement PinCreationForm with React Hook Form
+  - [x] 1.3 Write tests for form validation schema
+  - [x] 1.4 Implement zod validation for URL, title, description
+  - [x] 1.5 Add form field components using shadcn/ui
+  - [x] 1.6 Verify all component tests pass
 
 - [ ] 2. Implement pin creation route and action
   - [ ] 2.1 Write tests for /pins/new route component

--- a/apps/web/app/components/pins/PinCreationForm.test.tsx
+++ b/apps/web/app/components/pins/PinCreationForm.test.tsx
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { PinCreationForm } from './PinCreationForm'
+
+describe('PinCreationForm', () => {
+  const mockOnSubmit = vi.fn()
+  const mockOnMetadataFetch = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders all form fields (URL, title, description)', () => {
+    render(<PinCreationForm onSubmit={mockOnSubmit} />)
+
+    expect(screen.getByLabelText(/url/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/title/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/description/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /create pin/i })).toBeInTheDocument()
+  })
+
+  it('does not call onSubmit when URL is invalid', async () => {
+    const user = userEvent.setup()
+    render(<PinCreationForm onSubmit={mockOnSubmit} />)
+
+    const urlInput = screen.getByLabelText(/url/i)
+    const titleInput = screen.getByLabelText(/title/i)
+    const submitButton = screen.getByRole('button', { name: /create pin/i })
+
+    // Fill in invalid URL but valid title
+    await user.type(urlInput, 'not-a-valid-url')
+    await user.type(titleInput, 'Test Title')
+    await user.click(submitButton)
+
+    // Wait a bit to ensure form submission would have happened
+    await waitFor(() => {
+      expect(mockOnSubmit).not.toHaveBeenCalled()
+    })
+  })
+
+  it('does not call onSubmit when required fields are empty', async () => {
+    const user = userEvent.setup()
+    render(<PinCreationForm onSubmit={mockOnSubmit} />)
+
+    const submitButton = screen.getByRole('button', { name: /create pin/i })
+    await user.click(submitButton)
+
+    // Wait a bit to ensure form submission would have happened
+    await waitFor(() => {
+      expect(mockOnSubmit).not.toHaveBeenCalled()
+    })
+  })
+
+  it('calls onSubmit with correct data when form is valid', async () => {
+    const user = userEvent.setup()
+    render(<PinCreationForm onSubmit={mockOnSubmit} />)
+
+    const urlInput = screen.getByLabelText(/url/i)
+    const titleInput = screen.getByLabelText(/title/i)
+    const descriptionInput = screen.getByLabelText(/description/i)
+    const submitButton = screen.getByRole('button', { name: /create pin/i })
+
+    await user.type(urlInput, 'https://example.com')
+    await user.type(titleInput, 'Example Title')
+    await user.type(descriptionInput, 'Example description')
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockOnSubmit).toHaveBeenCalledWith({
+        url: 'https://example.com',
+        title: 'Example Title',
+        description: 'Example description'
+      })
+    })
+  })
+
+  it('disables submit button during loading state', () => {
+    render(<PinCreationForm onSubmit={mockOnSubmit} isLoading />)
+
+    const submitButton = screen.getByRole('button', { name: /creating/i })
+    expect(submitButton).toBeDisabled()
+  })
+
+  it('displays success message after successful submission', () => {
+    render(<PinCreationForm onSubmit={mockOnSubmit} successMessage="Pin created successfully!" />)
+
+    expect(screen.getByText('Pin created successfully!')).toBeInTheDocument()
+  })
+
+  it('displays error message when submission fails', () => {
+    render(<PinCreationForm onSubmit={mockOnSubmit} errorMessage="Failed to create pin" />)
+
+    expect(screen.getByText('Failed to create pin')).toBeInTheDocument()
+  })
+
+  it('auto-populates title when URL metadata is fetched', async () => {
+    const user = userEvent.setup()
+    render(
+      <PinCreationForm 
+        onSubmit={mockOnSubmit} 
+        onMetadataFetch={mockOnMetadataFetch}
+        metadataTitle="Fetched Page Title"
+      />
+    )
+
+    const urlInput = screen.getByLabelText(/url/i)
+    const titleInput = screen.getByLabelText(/title/i) as HTMLInputElement
+
+    await user.type(urlInput, 'https://example.com')
+    await user.tab() // Trigger blur event
+
+    await waitFor(() => {
+      expect(mockOnMetadataFetch).toHaveBeenCalledWith('https://example.com')
+    })
+
+    // Simulate metadata being fetched and passed back
+    expect(titleInput.value).toBe('Fetched Page Title')
+  })
+
+  it('allows manual override of auto-populated title', async () => {
+    const user = userEvent.setup()
+    render(
+      <PinCreationForm 
+        onSubmit={mockOnSubmit} 
+        metadataTitle="Fetched Page Title"
+      />
+    )
+
+    const titleInput = screen.getByLabelText(/title/i) as HTMLInputElement
+    
+    // Clear and type new title
+    await user.clear(titleInput)
+    await user.type(titleInput, 'My Custom Title')
+
+    expect(titleInput.value).toBe('My Custom Title')
+  })
+
+  it('handles metadata fetching errors gracefully', async () => {
+    const user = userEvent.setup()
+    render(
+      <PinCreationForm 
+        onSubmit={mockOnSubmit} 
+        onMetadataFetch={mockOnMetadataFetch}
+        metadataError="Failed to fetch metadata"
+      />
+    )
+
+    const urlInput = screen.getByLabelText(/url/i)
+    await user.type(urlInput, 'https://example.com')
+    await user.tab()
+
+    // Should not prevent form submission
+    const submitButton = screen.getByRole('button', { name: /create pin/i })
+    expect(submitButton).not.toBeDisabled()
+    
+    // Optionally show error but don't block functionality
+    expect(screen.queryByText(/failed to fetch metadata/i)).toBeInTheDocument()
+  })
+
+  it('shows loading state during metadata fetch', async () => {
+    render(
+      <PinCreationForm 
+        onSubmit={mockOnSubmit} 
+        isMetadataLoading
+      />
+    )
+
+    expect(screen.getByText(/fetching page title/i)).toBeInTheDocument()
+  })
+})

--- a/apps/web/app/components/pins/PinCreationForm.tsx
+++ b/apps/web/app/components/pins/PinCreationForm.tsx
@@ -1,0 +1,140 @@
+import { useEffect } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Button } from '~/components/ui/button'
+import { Input } from '~/components/ui/input'
+import { Textarea } from '~/components/ui/textarea'
+import { Label } from '~/components/ui/label'
+import { pinCreationSchema, type PinCreationFormData } from '~/lib/validation/pin-schema'
+
+interface PinCreationFormProps {
+  onSubmit: (data: PinCreationFormData) => void | Promise<void>
+  onMetadataFetch?: (url: string) => void
+  metadataTitle?: string
+  metadataError?: string
+  isMetadataLoading?: boolean
+  isLoading?: boolean
+  successMessage?: string
+  errorMessage?: string
+}
+
+export function PinCreationForm({
+  onSubmit,
+  onMetadataFetch,
+  metadataTitle,
+  metadataError,
+  isMetadataLoading,
+  isLoading,
+  successMessage,
+  errorMessage,
+}: PinCreationFormProps) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setValue,
+    watch,
+  } = useForm<PinCreationFormData>({
+    resolver: zodResolver(pinCreationSchema),
+  })
+
+  const onSubmitWrapper = (data: PinCreationFormData) => {
+    onSubmit(data)
+  }
+
+  const urlValue = watch('url')
+
+  // Auto-populate title when metadata is fetched
+  useEffect(() => {
+    if (metadataTitle) {
+      setValue('title', metadataTitle)
+    }
+  }, [metadataTitle, setValue])
+
+  const handleUrlBlur = () => {
+    if (urlValue && onMetadataFetch) {
+      try {
+        new URL(urlValue) // Validate URL before fetching
+        onMetadataFetch(urlValue)
+      } catch {
+        // Invalid URL, don't fetch metadata
+      }
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmitWrapper)} className="space-y-4">
+      {successMessage && (
+        <div className="rounded-md bg-green-50 p-4 text-sm text-green-800">
+          {successMessage}
+        </div>
+      )}
+
+      {errorMessage && (
+        <div className="rounded-md bg-red-50 p-4 text-sm text-red-800">
+          {errorMessage}
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <Label htmlFor="url">URL</Label>
+        <Input
+          id="url"
+          type="url"
+          placeholder="https://example.com"
+          {...register('url', { onBlur: handleUrlBlur })}
+          aria-invalid={!!errors.url}
+          aria-describedby={errors.url ? 'url-error' : undefined}
+        />
+        {errors.url && (
+          <p id="url-error" className="text-sm text-destructive">
+            {errors.url.message}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="title">Title</Label>
+        <div className="relative">
+          <Input
+            id="title"
+            type="text"
+            placeholder="Enter a title"
+            {...register('title')}
+            aria-invalid={!!errors.title}
+            aria-describedby={errors.title ? 'title-error' : undefined}
+          />
+          {isMetadataLoading && (
+            <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">
+              Fetching page title...
+            </span>
+          )}
+        </div>
+        {errors.title && (
+          <p id="title-error" className="text-sm text-destructive">
+            {errors.title.message}
+          </p>
+        )}
+        {metadataError && (
+          <p className="text-sm text-muted-foreground">
+            Failed to fetch metadata
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="description">Description (optional)</Label>
+        <Textarea
+          id="description"
+          placeholder="Add a description..."
+          {...register('description')}
+          rows={4}
+        />
+      </div>
+
+      <Button type="submit" disabled={isLoading} className="w-full">
+        {isLoading ? 'Creating...' : 'Create Pin'}
+      </Button>
+    </form>
+  )
+}

--- a/apps/web/app/components/ui/input.tsx
+++ b/apps/web/app/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react'
+import { cn } from '~/lib/utils'
+
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          'flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20',
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = 'Input'
+
+export { Input }

--- a/apps/web/app/components/ui/label.tsx
+++ b/apps/web/app/components/ui/label.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '~/lib/utils'
+
+const labelVariants = cva(
+  'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70'
+)
+
+const Label = React.forwardRef<
+  HTMLLabelElement,
+  React.ComponentProps<'label'> & VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <label
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+))
+Label.displayName = 'Label'
+
+export { Label }

--- a/apps/web/app/components/ui/textarea.tsx
+++ b/apps/web/app/components/ui/textarea.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react'
+import { cn } from '~/lib/utils'
+
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.ComponentProps<'textarea'>
+>(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      className={cn(
+        'flex min-h-[60px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20',
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  )
+})
+Textarea.displayName = 'Textarea'
+
+export { Textarea }

--- a/apps/web/app/lib/validation/pin-schema.test.ts
+++ b/apps/web/app/lib/validation/pin-schema.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest'
+import { pinCreationSchema } from './pin-schema'
+
+describe('pinCreationSchema', () => {
+  describe('url field', () => {
+    it('validates required URL field with proper format', () => {
+      const result = pinCreationSchema.safeParse({
+        url: 'https://example.com',
+        title: 'Test Title',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts URLs with different protocols', () => {
+      const httpsResult = pinCreationSchema.safeParse({
+        url: 'https://example.com',
+        title: 'Test Title',
+      })
+      expect(httpsResult.success).toBe(true)
+
+      const httpResult = pinCreationSchema.safeParse({
+        url: 'http://example.com',
+        title: 'Test Title',
+      })
+      expect(httpResult.success).toBe(true)
+    })
+
+    it('rejects empty URL field', () => {
+      const result = pinCreationSchema.safeParse({
+        url: '',
+        title: 'Test Title',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('URL is required')
+      }
+    })
+
+    it('rejects malformed URLs', () => {
+      const result = pinCreationSchema.safeParse({
+        url: 'not-a-valid-url',
+        title: 'Test Title',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('Invalid URL format')
+      }
+    })
+
+    it('rejects URLs without protocol', () => {
+      const result = pinCreationSchema.safeParse({
+        url: 'example.com',
+        title: 'Test Title',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('Invalid URL format')
+      }
+    })
+  })
+
+  describe('title field', () => {
+    it('validates required title field', () => {
+      const result = pinCreationSchema.safeParse({
+        url: 'https://example.com',
+        title: 'Test Title',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects empty title field', () => {
+      const result = pinCreationSchema.safeParse({
+        url: 'https://example.com',
+        title: '',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('Title is required')
+      }
+    })
+
+    it('rejects missing title field', () => {
+      const result = pinCreationSchema.safeParse({
+        url: 'https://example.com',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        // When field is missing, Zod returns "Invalid input" message
+        // We just need to ensure validation fails
+        expect(result.error.issues.length).toBeGreaterThan(0)
+      }
+    })
+  })
+
+  describe('description field', () => {
+    it('accepts optional description field', () => {
+      const result = pinCreationSchema.safeParse({
+        url: 'https://example.com',
+        title: 'Test Title',
+        description: 'This is a test description',
+      })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.description).toBe('This is a test description')
+      }
+    })
+
+    it('accepts missing description field', () => {
+      const result = pinCreationSchema.safeParse({
+        url: 'https://example.com',
+        title: 'Test Title',
+      })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.description).toBeUndefined()
+      }
+    })
+
+    it('accepts empty description field', () => {
+      const result = pinCreationSchema.safeParse({
+        url: 'https://example.com',
+        title: 'Test Title',
+        description: '',
+      })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.description).toBe('')
+      }
+    })
+  })
+
+  describe('complete validation', () => {
+    it('validates a complete valid pin creation object', () => {
+      const result = pinCreationSchema.safeParse({
+        url: 'https://example.com/article',
+        title: 'Interesting Article',
+        description: 'This article covers important topics',
+      })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data).toEqual({
+          url: 'https://example.com/article',
+          title: 'Interesting Article',
+          description: 'This article covers important topics',
+        })
+      }
+    })
+
+    it('rejects object with all empty fields', () => {
+      const result = pinCreationSchema.safeParse({
+        url: '',
+        title: '',
+        description: '',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        // Should have at least URL and title errors (description is optional)
+        expect(result.error.issues.length).toBeGreaterThanOrEqual(2)
+        const urlError = result.error.issues.find(issue => issue.path.includes('url'))
+        const titleError = result.error.issues.find(issue => issue.path.includes('title'))
+        expect(urlError?.message).toBe('URL is required')
+        expect(titleError?.message).toBe('Title is required')
+      }
+    })
+  })
+})

--- a/apps/web/app/lib/validation/pin-schema.ts
+++ b/apps/web/app/lib/validation/pin-schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod'
+
+export const pinCreationSchema = z.object({
+  url: z.string().min(1, 'URL is required').url('Invalid URL format'),
+  title: z.string().min(1, 'Title is required'),
+  description: z.string().optional(),
+})
+
+export type PinCreationFormData = z.infer<typeof pinCreationSchema>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "test:coverage": "vitest --run --coverage"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.1",
     "@pinsquirrel/core": "workspace:*",
     "@pinsquirrel/database": "workspace:*",
     "@radix-ui/react-slot": "^1.2.3",
@@ -27,6 +28,7 @@
     "lucide-react": "^0.525.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-hook-form": "^7.62.0",
     "react-router": "^7.5.3",
     "tailwind-merge": "^3.3.1",
     "zod": "^4.0.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^5.2.1
+        version: 5.2.1(react-hook-form@7.62.0(react@19.1.0))
       '@pinsquirrel/core':
         specifier: workspace:*
         version: link:../../libs/core
@@ -51,6 +54,9 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
+      react-hook-form:
+        specifier: ^7.62.0
+        version: 7.62.0(react@19.1.0)
       react-router:
         specifier: ^7.5.3
         version: 7.6.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -848,6 +854,11 @@ packages:
     resolution: {integrity: sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@hookform/resolvers@5.2.1':
+    resolution: {integrity: sha512-u0+6X58gkjMcxur1wRWokA7XsiiBJ6aK17aPZxhkoYiK5J+HcTx0Vhu9ovXe6H+dVpO6cjrn2FkJTryXEMlryQ==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -1094,6 +1105,9 @@ packages:
     resolution: {integrity: sha512-3+QZROYfJ25PDcxFF66UEk8jGWigHJeecZILvkPkyQN7oc5BvFo4YEXFkOs154j3FTMp9mn9Ky8RCOwastduEA==}
     cpu: [x64]
     os: [win32]
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@tailwindcss/node@4.1.11':
     resolution: {integrity: sha512-yzhzuGRmv5QyU9qLNg4GTlYI6STedBWRE7NjxP45CsFYYq9taI0zJXZBMqIC/c8fViNLhmrbpSFS57EoxUmD6Q==}
@@ -2940,6 +2954,12 @@ packages:
     peerDependencies:
       react: ^19.1.0
 
+  react-hook-form@7.62.0:
+    resolution: {integrity: sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -4020,6 +4040,11 @@ snapshots:
       '@eslint/core': 0.15.1
       levn: 0.4.1
 
+  '@hookform/resolvers@5.2.1(react-hook-form@7.62.0(react@19.1.0))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.62.0(react@19.1.0)
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -4264,6 +4289,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.44.2':
     optional: true
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@tailwindcss/node@4.1.11':
     dependencies:
@@ -6202,6 +6229,10 @@ snapshots:
     dependencies:
       react: 19.1.0
       scheduler: 0.26.0
+
+  react-hook-form@7.62.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
 
   react-is@16.13.1: {}
 


### PR DESCRIPTION
- Add PinCreationForm component with React Hook Form integration
- Implement Zod validation schema for URL, title, and description fields
- Create shadcn/ui components: Input, Textarea, Label
- Add comprehensive test coverage (24 tests)
- Support auto-title fetching and metadata loading states
- Include proper accessibility with ARIA labels
- Complete Task 1 of pin creation form specification

🤖 Generated with [Claude Code](https://claude.ai/code)