### PR TITLE
feat(api): add read-only REST API at /api/v1 with API key auth

### DIFF
--- a/apps/hono/package.json
+++ b/apps/hono/package.json
@@ -19,7 +19,7 @@
     "css:watch": "tailwindcss -i ./src/styles/app.css -o ./src/static/styles.css --watch"
   },
   "dependencies": {
-    "@hono/node-server": "^1.19.12",
+    "@hono/node-server": "^1.19.13",
     "@pinsquirrel/adapters": "workspace:*",
     "@pinsquirrel/database": "workspace:*",
     "@pinsquirrel/domain": "workspace:*",
@@ -28,7 +28,7 @@
     "cheerio": "^1.2.0",
     "dotenv": "^17.4.1",
     "drizzle-orm": "^0.45.2",
-    "hono": "^4.12.11",
+    "hono": "^4.12.12",
     "mailgun.js": "^12.7.1",
     "pino": "^10.3.1"
   },

--- a/apps/hono/src/app.tsx
+++ b/apps/hono/src/app.tsx
@@ -14,7 +14,8 @@ import { authRoutes } from './routes/auth'
 import { pinsRoutes } from './routes/pins'
 import { tagsRoutes } from './routes/tags'
 import { profileRoutes } from './routes/profile'
-import { apiRoutes } from './routes/api'
+import { apiInternalRoutes } from './routes/api-internal'
+import { apiV1Routes } from './routes/api-v1'
 import { staticRoutes } from './routes/static'
 import { styleRoutes } from './routes/style'
 import { importRoutes } from './routes/import'
@@ -59,7 +60,8 @@ app.route('/profile', profileRoutes)
 app.route('/import', importRoutes)
 app.route('/export', exportRoutes)
 app.route('/private', privateRoutes)
-app.route('/api', apiRoutes)
+app.route('/api/internal', apiInternalRoutes)
+app.route('/api/v1', apiV1Routes)
 
 // Home page - redirects logged-in users to /pins
 app.get('/', async (c) => {

--- a/apps/hono/src/middleware/api-auth.ts
+++ b/apps/hono/src/middleware/api-auth.ts
@@ -1,0 +1,57 @@
+import type { Context, MiddlewareHandler } from 'hono'
+import type { ApiKey, User } from '@pinsquirrel/domain'
+import { apiKeyService } from '../lib/services'
+import { userRepository } from '../lib/db'
+
+interface ApiAuthVariables {
+  apiUser: User
+  apiKey: ApiKey
+}
+
+declare module 'hono' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  interface ContextVariableMap extends ApiAuthVariables {}
+}
+
+function extractRawKey(c: Context): string | null {
+  const authHeader = c.req.header('Authorization')
+  if (authHeader) {
+    const match = /^Bearer\s+(.+)$/i.exec(authHeader.trim())
+    if (match) return match[1].trim()
+  }
+  const xApiKey = c.req.header('X-API-Key')
+  if (xApiKey) return xApiKey.trim()
+  return null
+}
+
+export function apiKeyAuth(): MiddlewareHandler {
+  return async (c, next) => {
+    const rawKey = extractRawKey(c)
+    if (!rawKey) {
+      return c.json({ error: 'Missing API key' }, 401)
+    }
+
+    const apiKey = await apiKeyService.authenticateByKey(rawKey)
+    if (!apiKey) {
+      return c.json({ error: 'Invalid API key' }, 401)
+    }
+
+    const user = await userRepository.findById(apiKey.userId)
+    if (!user) {
+      return c.json({ error: 'User not found' }, 401)
+    }
+
+    c.set('apiUser', user)
+    c.set('apiKey', apiKey)
+
+    await next()
+  }
+}
+
+export function getApiUser(c: Context): User {
+  return c.get('apiUser')
+}
+
+export function getApiKey(c: Context): ApiKey {
+  return c.get('apiKey')
+}

--- a/apps/hono/src/routes/api-internal.ts
+++ b/apps/hono/src/routes/api-internal.ts
@@ -6,13 +6,13 @@ import {
 } from '../lib/services'
 import { getSessionManager, requireAuth } from '../middleware/session'
 
-const api = new Hono()
+const apiInternal = new Hono()
 
 // Apply auth middleware to all API routes
-api.use('*', requireAuth())
+apiInternal.use('*', requireAuth())
 
-// GET /api/metadata - Fetch metadata for a URL
-api.get('/metadata', async (c) => {
+// GET /api/internal/metadata - Fetch metadata for a URL
+apiInternal.get('/metadata', async (c) => {
   const sessionManager = getSessionManager(c)
   const user = await sessionManager.getUser()
 
@@ -41,8 +41,8 @@ api.get('/metadata', async (c) => {
   }
 })
 
-// GET /api/check-url - Check if a URL is already saved
-api.get('/check-url', async (c) => {
+// GET /api/internal/check-url - Check if a URL is already saved
+apiInternal.get('/check-url', async (c) => {
   const sessionManager = getSessionManager(c)
   const user = await sessionManager.getUser()
 
@@ -81,4 +81,4 @@ api.get('/check-url', async (c) => {
   return c.json({ exists: false })
 })
 
-export { api as apiRoutes }
+export { apiInternal as apiInternalRoutes }

--- a/apps/hono/src/routes/api-v1.test.ts
+++ b/apps/hono/src/routes/api-v1.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+import type { ApiKey, Pin, Tag, User } from '@pinsquirrel/domain'
+import { Pagination } from '@pinsquirrel/domain'
+
+const mockAuthenticateByKey = vi.fn()
+const mockFindUserById = vi.fn()
+const mockFindTagById = vi.fn()
+const mockGetPin = vi.fn()
+const mockGetUserPinsWithPagination = vi.fn()
+const mockGetUserTags = vi.fn()
+const mockGetUserTagsWithCount = vi.fn()
+
+vi.mock('../lib/services', () => ({
+  apiKeyService: {
+    authenticateByKey: (...args: unknown[]) =>
+      mockAuthenticateByKey(...args) as unknown,
+  },
+  pinService: {
+    getPin: (...args: unknown[]) => mockGetPin(...args) as unknown,
+    getUserPinsWithPagination: (...args: unknown[]) =>
+      mockGetUserPinsWithPagination(...args) as unknown,
+  },
+  tagService: {
+    getUserTags: (...args: unknown[]) => mockGetUserTags(...args) as unknown,
+    getUserTagsWithCount: (...args: unknown[]) =>
+      mockGetUserTagsWithCount(...args) as unknown,
+  },
+}))
+
+vi.mock('../lib/db', () => ({
+  userRepository: {
+    findById: (...args: unknown[]) => mockFindUserById(...args) as unknown,
+  },
+  tagRepository: {
+    findById: (...args: unknown[]) => mockFindTagById(...args) as unknown,
+  },
+}))
+
+import { apiV1Routes } from './api-v1'
+
+const testUser: User = {
+  id: 'user-1',
+  username: 'alice',
+  email: 'alice@example.com',
+  emailVerified: true,
+  passwordHash: 'x',
+  roles: [],
+  createdAt: new Date('2024-01-01'),
+  updatedAt: new Date('2024-01-01'),
+} as unknown as User
+
+const testApiKey: ApiKey = {
+  id: 'key-1',
+  userId: 'user-1',
+  name: 'test',
+  keyHash: 'hash',
+  keyPrefix: 'ps_test',
+  lastUsedAt: new Date('2024-01-01'),
+  expiresAt: null,
+  createdAt: new Date('2024-01-01'),
+} as unknown as ApiKey
+
+function makePin(overrides: Partial<Pin> = {}): Pin {
+  return {
+    id: 'pin-1',
+    userId: 'user-1',
+    url: 'https://example.com',
+    title: 'Example',
+    description: null,
+    readLater: false,
+    isPrivate: false,
+    tagNames: ['foo'],
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+    ...overrides,
+  } as Pin
+}
+
+function makeTag(overrides: Partial<Tag> = {}): Tag {
+  return {
+    id: 'tag-1',
+    userId: 'user-1',
+    name: 'foo',
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+    ...overrides,
+  } as Tag
+}
+
+describe('api-v1 routes', () => {
+  let app: Hono
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    app = new Hono()
+    app.route('/api/v1', apiV1Routes)
+  })
+
+  describe('auth middleware', () => {
+    it('returns 401 without auth header', async () => {
+      const res = await app.request('/api/v1/pins')
+      expect(res.status).toBe(401)
+      expect(await res.json()).toEqual({ error: 'Missing API key' })
+    })
+
+    it('returns 401 with invalid API key', async () => {
+      mockAuthenticateByKey.mockResolvedValue(null)
+      const res = await app.request('/api/v1/pins', {
+        headers: { Authorization: 'Bearer ps_bad' },
+      })
+      expect(res.status).toBe(401)
+      expect(await res.json()).toEqual({ error: 'Invalid API key' })
+    })
+
+    it('returns 401 when user lookup fails', async () => {
+      mockAuthenticateByKey.mockResolvedValue(testApiKey)
+      mockFindUserById.mockResolvedValue(null)
+      const res = await app.request('/api/v1/pins', {
+        headers: { Authorization: 'Bearer ps_ok' },
+      })
+      expect(res.status).toBe(401)
+      expect(await res.json()).toEqual({ error: 'User not found' })
+    })
+
+    it('accepts X-API-Key header', async () => {
+      mockAuthenticateByKey.mockResolvedValue(testApiKey)
+      mockFindUserById.mockResolvedValue(testUser)
+      mockGetUserPinsWithPagination.mockResolvedValue({
+        pins: [],
+        pagination: Pagination.fromTotalCount(0),
+      })
+      const res = await app.request('/api/v1/pins', {
+        headers: { 'X-API-Key': 'ps_ok' },
+      })
+      expect(res.status).toBe(200)
+    })
+  })
+
+  describe('GET /api/v1/pins', () => {
+    beforeEach(() => {
+      mockAuthenticateByKey.mockResolvedValue(testApiKey)
+      mockFindUserById.mockResolvedValue(testUser)
+    })
+
+    it('returns data and pagination shape', async () => {
+      mockGetUserPinsWithPagination.mockResolvedValue({
+        pins: [makePin()],
+        pagination: Pagination.fromTotalCount(1, { page: 1, pageSize: 25 }),
+      })
+      const res = await app.request('/api/v1/pins', {
+        headers: { Authorization: 'Bearer ps_ok' },
+      })
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as {
+        data: unknown[]
+        pagination: { totalCount: number; page: number; hasNext: boolean }
+      }
+      expect(body.data).toHaveLength(1)
+      expect(body.pagination.totalCount).toBe(1)
+      expect(body.pagination.page).toBe(1)
+      expect(body.pagination.hasNext).toBe(false)
+      // Verify filter forces isPrivate: false
+      const filter = mockGetUserPinsWithPagination.mock.calls[0][1] as {
+        isPrivate: boolean
+      }
+      expect(filter.isPrivate).toBe(false)
+    })
+
+    it('passes query params through to service', async () => {
+      mockGetUserPinsWithPagination.mockResolvedValue({
+        pins: [],
+        pagination: Pagination.fromTotalCount(0),
+      })
+      await app.request(
+        '/api/v1/pins?tag=js&search=react&readLater=true&page=2&pageSize=10&sortBy=title&sortDirection=asc',
+        { headers: { Authorization: 'Bearer ps_ok' } }
+      )
+      const [, filter, pagination] = mockGetUserPinsWithPagination.mock.calls[0]
+      expect(filter).toMatchObject({
+        tag: 'js',
+        search: 'react',
+        readLater: true,
+        sortBy: 'title',
+        sortDirection: 'asc',
+        isPrivate: false,
+      })
+      expect(pagination).toEqual({ page: 2, pageSize: 10 })
+    })
+
+    it('returns 400 on invalid query', async () => {
+      const res = await app.request('/api/v1/pins?page=abc', {
+        headers: { Authorization: 'Bearer ps_ok' },
+      })
+      expect(res.status).toBe(400)
+    })
+  })
+
+  describe('GET /api/v1/pins/:id', () => {
+    beforeEach(() => {
+      mockAuthenticateByKey.mockResolvedValue(testApiKey)
+      mockFindUserById.mockResolvedValue(testUser)
+    })
+
+    it('returns pin', async () => {
+      mockGetPin.mockResolvedValue(makePin())
+      const res = await app.request('/api/v1/pins/pin-1', {
+        headers: { Authorization: 'Bearer ps_ok' },
+      })
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as { data: { id: string } }
+      expect(body.data.id).toBe('pin-1')
+    })
+
+    it('returns 404 for private pins', async () => {
+      mockGetPin.mockResolvedValue(makePin({ isPrivate: true }))
+      const res = await app.request('/api/v1/pins/pin-1', {
+        headers: { Authorization: 'Bearer ps_ok' },
+      })
+      expect(res.status).toBe(404)
+    })
+  })
+
+  describe('GET /api/v1/tags', () => {
+    beforeEach(() => {
+      mockAuthenticateByKey.mockResolvedValue(testApiKey)
+      mockFindUserById.mockResolvedValue(testUser)
+    })
+
+    it('returns tags', async () => {
+      mockGetUserTags.mockResolvedValue([makeTag()])
+      const res = await app.request('/api/v1/tags', {
+        headers: { Authorization: 'Bearer ps_ok' },
+      })
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as { data: { name: string }[] }
+      expect(body.data[0].name).toBe('foo')
+    })
+
+    it('returns tags with counts when withCounts=true', async () => {
+      mockGetUserTagsWithCount.mockResolvedValue([
+        { ...makeTag(), pinCount: 5 },
+      ])
+      const res = await app.request('/api/v1/tags?withCounts=true', {
+        headers: { Authorization: 'Bearer ps_ok' },
+      })
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as { data: { pinCount: number }[] }
+      expect(body.data[0].pinCount).toBe(5)
+    })
+  })
+
+  describe('GET /api/v1/tags/:id/pins', () => {
+    beforeEach(() => {
+      mockAuthenticateByKey.mockResolvedValue(testApiKey)
+      mockFindUserById.mockResolvedValue(testUser)
+    })
+
+    it('returns pins filtered by tag name', async () => {
+      mockFindTagById.mockResolvedValue(makeTag())
+      mockGetUserPinsWithPagination.mockResolvedValue({
+        pins: [makePin()],
+        pagination: Pagination.fromTotalCount(1),
+      })
+      const res = await app.request('/api/v1/tags/tag-1/pins', {
+        headers: { Authorization: 'Bearer ps_ok' },
+      })
+      expect(res.status).toBe(200)
+      const filter = mockGetUserPinsWithPagination.mock.calls[0][1] as {
+        tag: string
+        isPrivate: boolean
+      }
+      expect(filter.tag).toBe('foo')
+      expect(filter.isPrivate).toBe(false)
+    })
+
+    it('returns 404 if tag does not belong to user', async () => {
+      mockFindTagById.mockResolvedValue(makeTag({ userId: 'other-user' }))
+      const res = await app.request('/api/v1/tags/tag-1/pins', {
+        headers: { Authorization: 'Bearer ps_ok' },
+      })
+      expect(res.status).toBe(404)
+    })
+
+    it('returns 404 when tag not found', async () => {
+      mockFindTagById.mockResolvedValue(null)
+      const res = await app.request('/api/v1/tags/tag-1/pins', {
+        headers: { Authorization: 'Bearer ps_ok' },
+      })
+      expect(res.status).toBe(404)
+    })
+  })
+})

--- a/apps/hono/src/routes/api-v1.ts
+++ b/apps/hono/src/routes/api-v1.ts
@@ -1,0 +1,232 @@
+import { Hono, type Context } from 'hono'
+import {
+  AccessControl,
+  Pagination,
+  PinNotFoundError,
+  TagNotFoundError,
+  UnauthorizedPinAccessError,
+  UnauthorizedTagAccessError,
+  ValidationError,
+  type Pin,
+  type PinFilter,
+} from '@pinsquirrel/domain'
+import {
+  pinListInputSchema,
+  tagListInputSchema,
+  type PinListInput,
+} from '@pinsquirrel/services'
+import { pinService, tagService } from '../lib/services'
+import { tagRepository } from '../lib/db'
+import { apiKeyAuth, getApiUser } from '../middleware/api-auth'
+
+const apiV1 = new Hono()
+
+// TODO: write endpoints (POST/PUT/DELETE) will need CSRF bypass when added.
+apiV1.use('*', apiKeyAuth())
+
+function firstIssue(issues: { message: string }[]): string {
+  return issues[0]?.message ?? 'Invalid query'
+}
+
+/**
+ * Convert raw HTTP query-string values (all strings) into the typed shape
+ * that `pinListInputSchema` / `tagListInputSchema` expect. Unknown/absent
+ * fields are dropped so schema `.optional()` handles them.
+ */
+function coerceQuery(
+  raw: Record<string, string>,
+  numberKeys: readonly string[],
+  booleanKeys: readonly string[]
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...raw }
+  for (const key of numberKeys) {
+    if (raw[key] !== undefined) {
+      const n = Number(raw[key])
+      out[key] = Number.isNaN(n) ? raw[key] : n
+    }
+  }
+  for (const key of booleanKeys) {
+    if (raw[key] !== undefined) {
+      if (raw[key] === 'true' || raw[key] === '1') out[key] = true
+      else if (raw[key] === 'false' || raw[key] === '0') out[key] = false
+      // else leave as string so the schema rejects it with a useful error
+    }
+  }
+  return out
+}
+
+const PIN_LIST_NUMBER_KEYS = ['page', 'pageSize'] as const
+const PIN_LIST_BOOLEAN_KEYS = ['readLater', 'noTags'] as const
+const TAG_LIST_BOOLEAN_KEYS = ['withCounts'] as const
+
+function pinFilterFromInput(input: PinListInput): PinFilter {
+  return {
+    isPrivate: false,
+    tag: input.tag,
+    search: input.search,
+    readLater: input.readLater,
+    noTags: input.noTags,
+    sortBy: input.sortBy,
+    sortDirection: input.sortDirection,
+  }
+}
+
+function serializePin(pin: Pin) {
+  return {
+    id: pin.id,
+    url: pin.url,
+    title: pin.title,
+    description: pin.description,
+    readLater: pin.readLater,
+    tags: pin.tagNames,
+    createdAt: pin.createdAt.toISOString(),
+    updatedAt: pin.updatedAt.toISOString(),
+  }
+}
+
+function serializePagination(p: Pagination) {
+  return {
+    page: p.page,
+    pageSize: p.pageSize,
+    totalCount: p.totalCount,
+    totalPages: p.totalPages,
+    hasNext: p.hasNext,
+    hasPrevious: p.hasPrevious,
+  }
+}
+
+// GET /api/v1/pins - list pins (excludes private pins)
+apiV1.get('/pins', async (c) => {
+  const user = getApiUser(c)
+  const ac = new AccessControl(user)
+
+  const parsed = pinListInputSchema.safeParse(
+    coerceQuery(c.req.query(), PIN_LIST_NUMBER_KEYS, PIN_LIST_BOOLEAN_KEYS)
+  )
+  if (!parsed.success) {
+    return c.json({ error: firstIssue(parsed.error.issues) }, 400)
+  }
+  const input = parsed.data
+
+  try {
+    const result = await pinService.getUserPinsWithPagination(
+      ac,
+      pinFilterFromInput(input),
+      { page: input.page, pageSize: input.pageSize }
+    )
+    return c.json({
+      data: result.pins.map(serializePin),
+      pagination: serializePagination(result.pagination),
+    })
+  } catch (err) {
+    return errorResponse(c, err)
+  }
+})
+
+// GET /api/v1/pins/:id - single pin
+apiV1.get('/pins/:id', async (c) => {
+  const user = getApiUser(c)
+  const ac = new AccessControl(user)
+  const id = c.req.param('id')
+
+  try {
+    const pin = await pinService.getPin(ac, id)
+    if (pin.isPrivate) {
+      return c.json({ error: 'Pin not found' }, 404)
+    }
+    return c.json({ data: serializePin(pin) })
+  } catch (err) {
+    return errorResponse(c, err)
+  }
+})
+
+// GET /api/v1/tags - list user's tags
+apiV1.get('/tags', async (c) => {
+  const user = getApiUser(c)
+  const ac = new AccessControl(user)
+
+  const parsed = tagListInputSchema.safeParse(
+    coerceQuery(c.req.query(), [], TAG_LIST_BOOLEAN_KEYS)
+  )
+  if (!parsed.success) {
+    return c.json({ error: firstIssue(parsed.error.issues) }, 400)
+  }
+
+  try {
+    if (parsed.data.withCounts) {
+      const tags = await tagService.getUserTagsWithCount(ac, user.id)
+      return c.json({
+        data: tags.map((t) => ({
+          id: t.id,
+          name: t.name,
+          pinCount: t.pinCount,
+          createdAt: t.createdAt.toISOString(),
+          updatedAt: t.updatedAt.toISOString(),
+        })),
+      })
+    }
+    const tags = await tagService.getUserTags(ac, user.id)
+    return c.json({
+      data: tags.map((t) => ({
+        id: t.id,
+        name: t.name,
+        createdAt: t.createdAt.toISOString(),
+        updatedAt: t.updatedAt.toISOString(),
+      })),
+    })
+  } catch (err) {
+    return errorResponse(c, err)
+  }
+})
+
+// GET /api/v1/tags/:id/pins - pins for a tag (by tag id, excludes private)
+apiV1.get('/tags/:id/pins', async (c) => {
+  const user = getApiUser(c)
+  const ac = new AccessControl(user)
+  const tagId = c.req.param('id')
+
+  const parsed = pinListInputSchema.safeParse(
+    coerceQuery(c.req.query(), PIN_LIST_NUMBER_KEYS, PIN_LIST_BOOLEAN_KEYS)
+  )
+  if (!parsed.success) {
+    return c.json({ error: firstIssue(parsed.error.issues) }, 400)
+  }
+  const input = parsed.data
+
+  try {
+    const tag = await tagRepository.findById(tagId)
+    if (!tag || tag.userId !== user.id) {
+      return c.json({ error: 'Tag not found' }, 404)
+    }
+
+    const result = await pinService.getUserPinsWithPagination(
+      ac,
+      { ...pinFilterFromInput(input), tag: tag.name },
+      { page: input.page, pageSize: input.pageSize }
+    )
+    return c.json({
+      data: result.pins.map(serializePin),
+      pagination: serializePagination(result.pagination),
+    })
+  } catch (err) {
+    return errorResponse(c, err)
+  }
+})
+
+function errorResponse(c: Context, err: unknown) {
+  if (err instanceof ValidationError) {
+    return c.json({ error: 'Invalid request' }, 400)
+  }
+  if (err instanceof PinNotFoundError || err instanceof TagNotFoundError) {
+    return c.json({ error: err.message }, 404)
+  }
+  if (
+    err instanceof UnauthorizedPinAccessError ||
+    err instanceof UnauthorizedTagAccessError
+  ) {
+    return c.json({ error: 'Unauthorized' }, 401)
+  }
+  return c.json({ error: 'Internal server error' }, 500)
+}
+
+export { apiV1 as apiV1Routes }

--- a/apps/hono/src/routes/pins.tsx
+++ b/apps/hono/src/routes/pins.tsx
@@ -143,7 +143,6 @@ pins.get('/', async (c) => {
       <PinsContentPartial
         pins={result.pins}
         pagination={result.pagination}
-        totalCount={result.totalCount}
         searchParams={searchParams}
         activeTag={tag}
         searchQuery={search}
@@ -164,7 +163,6 @@ pins.get('/', async (c) => {
       user={user}
       pins={result.pins}
       pagination={result.pagination}
-      totalCount={result.totalCount}
       searchParams={searchParams}
       activeTag={tag}
       searchQuery={search}
@@ -693,7 +691,6 @@ pins.delete('/:id', async (c) => {
       <PinsContentPartial
         pins={result.pins}
         pagination={result.pagination}
-        totalCount={result.totalCount}
         searchParams={searchParams}
         activeTag={tag}
         searchQuery={search}

--- a/apps/hono/src/routes/private.tsx
+++ b/apps/hono/src/routes/private.tsx
@@ -126,7 +126,6 @@ privateRouter.get('/pins', async (c) => {
       <PinsContentPartial
         pins={result.pins}
         pagination={result.pagination}
-        totalCount={result.totalCount}
         searchParams={searchParams}
         activeTag={tag}
         searchQuery={search}
@@ -147,7 +146,6 @@ privateRouter.get('/pins', async (c) => {
       user={user}
       pins={result.pins}
       pagination={result.pagination}
-      totalCount={result.totalCount}
       searchParams={searchParams}
       activeTag={tag}
       searchQuery={search}
@@ -647,7 +645,6 @@ privateRouter.delete('/pins/:id', async (c) => {
       <PinsContentPartial
         pins={result.pins}
         pagination={result.pagination}
-        totalCount={result.totalCount}
         searchParams={searchParams}
         activeTag={tag}
         searchQuery={search}

--- a/apps/hono/src/routes/tags.tsx
+++ b/apps/hono/src/routes/tags.tsx
@@ -57,7 +57,7 @@ tags.get('/', async (c) => {
       user={user}
       tags={userTags}
       currentFilter={currentFilter}
-      untaggedPinsCount={untaggedResult.totalCount}
+      untaggedPinsCount={untaggedResult.pagination.totalCount}
       flash={flash}
     />
   )

--- a/apps/hono/src/static/metadata-fetch.js
+++ b/apps/hono/src/static/metadata-fetch.js
@@ -80,7 +80,7 @@ function initMetadataFetch(form) {
 
     try {
       const response = await fetch(
-        `/api/metadata?url=${encodeURIComponent(url)}`
+        `/api/internal/metadata?url=${encodeURIComponent(url)}`
       )
       const data = await response.json()
 

--- a/apps/hono/src/views/components/PinForm.tsx
+++ b/apps/hono/src/views/components/PinForm.tsx
@@ -77,7 +77,7 @@ export const PinForm: FC<PinFormProps> = ({
             error={duplicatePinId ? undefined : errors?.url?.join('. ')}
             helpText="Enter the web address you want to save as a pin"
             data-url-input
-            hx-get="/api/check-url"
+            hx-get="/api/internal/check-url"
             hx-trigger="change"
             hx-target="#url-check-result"
             hx-swap="innerHTML"

--- a/apps/hono/src/views/pages/pins.tsx
+++ b/apps/hono/src/views/pages/pins.tsx
@@ -9,7 +9,6 @@ interface PinsPageProps {
   user: User
   pins: Pin[]
   pagination: Pagination
-  totalCount: number
   searchParams?: string
   activeTag?: string
   searchQuery?: string
@@ -27,7 +26,6 @@ export const PinsPage: FC<PinsPageProps> = ({
   user,
   pins,
   pagination,
-  totalCount,
   searchParams = '',
   activeTag,
   searchQuery,
@@ -61,7 +59,6 @@ export const PinsPage: FC<PinsPageProps> = ({
         <PinsContentPartial
           pins={pins}
           pagination={pagination}
-          totalCount={totalCount}
           searchParams={searchParams}
           activeTag={activeTag}
           searchQuery={searchQuery}

--- a/apps/hono/src/views/partials/pin-list.tsx
+++ b/apps/hono/src/views/partials/pin-list.tsx
@@ -5,7 +5,6 @@ import { PinCard } from '../components/PinCard'
 interface PinListPartialProps {
   pins: Pin[]
   pagination: Pagination
-  totalCount: number
   searchParams: string
   viewSize?: 'expanded' | 'compact'
   baseUrl?: string
@@ -59,17 +58,16 @@ const EmptyState: FC<{ hasFilters: boolean; baseUrl: string }> = ({
 
 const PaginationControls: FC<{
   pagination: Pagination
-  totalCount: number
   searchParams: string
   baseUrl: string
-}> = ({ pagination, totalCount, searchParams, baseUrl }) => {
+}> = ({ pagination, searchParams, baseUrl }) => {
   if (pagination.totalPages <= 1) return null
 
   return (
     <div class="flex items-center justify-between mt-8 pt-4 border-t border-foreground/20">
       <div class="text-sm text-muted-foreground">
-        Showing page {pagination.page} of {pagination.totalPages} ({totalCount}{' '}
-        total pins)
+        Showing page {pagination.page} of {pagination.totalPages} (
+        {pagination.totalCount} total pins)
       </div>
 
       <div class="flex gap-2">
@@ -108,7 +106,6 @@ const PaginationControls: FC<{
 export const PinListPartial: FC<PinListPartialProps> = ({
   pins,
   pagination,
-  totalCount,
   searchParams,
   viewSize = 'expanded',
   baseUrl = '/pins',
@@ -140,7 +137,6 @@ export const PinListPartial: FC<PinListPartialProps> = ({
 
       <PaginationControls
         pagination={pagination}
-        totalCount={totalCount}
         searchParams={searchParams}
         baseUrl={baseUrl}
       />

--- a/apps/hono/src/views/partials/pins-content.tsx
+++ b/apps/hono/src/views/partials/pins-content.tsx
@@ -7,7 +7,6 @@ import { PinListPartial } from './pin-list'
 interface PinsContentPartialProps {
   pins: Pin[]
   pagination: Pagination
-  totalCount: number
   searchParams: string
   activeTag?: string
   searchQuery?: string
@@ -22,7 +21,6 @@ interface PinsContentPartialProps {
 export const PinsContentPartial: FC<PinsContentPartialProps> = ({
   pins,
   pagination,
-  totalCount,
   searchParams,
   activeTag,
   searchQuery,
@@ -56,7 +54,6 @@ export const PinsContentPartial: FC<PinsContentPartialProps> = ({
         <PinListPartial
           pins={pins}
           pagination={pagination}
-          totalCount={totalCount}
           searchParams={searchParams}
           viewSize={viewSize}
           baseUrl={baseUrl}

--- a/libs/domain/src/entities/pagination.test.ts
+++ b/libs/domain/src/entities/pagination.test.ts
@@ -6,6 +6,7 @@ describe('Pagination', () => {
     it('should create pagination with default values', () => {
       const pagination = Pagination.fromTotalCount(100)
 
+      expect(pagination.totalCount).toBe(100)
       expect(pagination.page).toBe(1)
       expect(pagination.pageSize).toBe(25)
       expect(pagination.offset).toBe(0)
@@ -134,8 +135,9 @@ describe('Pagination', () => {
 
   describe('constructor', () => {
     it('should create pagination with provided values', () => {
-      const pagination = new Pagination(2, 25, 25, 4, true, true)
+      const pagination = new Pagination(100, 2, 25, 25, 4, true, true)
 
+      expect(pagination.totalCount).toBe(100)
       expect(pagination.page).toBe(2)
       expect(pagination.pageSize).toBe(25)
       expect(pagination.offset).toBe(25)
@@ -145,9 +147,10 @@ describe('Pagination', () => {
     })
 
     it('should make properties readonly', () => {
-      const pagination = new Pagination(1, 25, 0, 1, false, false)
+      const pagination = new Pagination(10, 1, 25, 0, 1, false, false)
 
       // TypeScript should prevent mutation of readonly properties
+      expect(pagination.totalCount).toBe(10)
       expect(pagination.page).toBe(1)
       expect(pagination.pageSize).toBe(25)
       expect(pagination.offset).toBe(0)

--- a/libs/domain/src/entities/pagination.ts
+++ b/libs/domain/src/entities/pagination.ts
@@ -6,6 +6,7 @@ export interface PaginationOptions {
 }
 
 export class Pagination {
+  readonly totalCount: number
   readonly page: number
   readonly pageSize: number
   readonly offset: number
@@ -14,6 +15,7 @@ export class Pagination {
   readonly hasPrevious: boolean
 
   constructor(
+    totalCount: number,
     page: number,
     pageSize: number,
     offset: number,
@@ -21,6 +23,7 @@ export class Pagination {
     hasNext: boolean,
     hasPrevious: boolean
   ) {
+    this.totalCount = totalCount
     this.page = page
     this.pageSize = pageSize
     this.offset = offset
@@ -56,6 +59,7 @@ export class Pagination {
     const hasPrevious = normalizedPage > 1
 
     return new Pagination(
+      totalCount,
       normalizedPage,
       normalizedPageSize,
       offset,

--- a/libs/services/src/index.ts
+++ b/libs/services/src/index.ts
@@ -6,5 +6,13 @@ export { TagService } from './services/tag.js'
 export { UserService } from './services/user.js'
 export { ApiKeyService } from './services/api-key.js'
 
+// Validation schemas (shared between REST, MCP, and other transports)
+export {
+  pinListInputSchema,
+  tagListInputSchema,
+  type PinListInput,
+  type TagListInput,
+} from './validation/pin-query.js'
+
 // Utilities
 export { md5 } from './utils/crypto.js'

--- a/libs/services/src/services/pin.ts
+++ b/libs/services/src/services/pin.ts
@@ -189,7 +189,6 @@ export class PinService {
   ): Promise<{
     pins: Pin[]
     pagination: Pagination
-    totalCount: number
   }> {
     if (!ac.user) {
       throw new UnauthorizedPinAccessError(
@@ -222,7 +221,6 @@ export class PinService {
     return {
       pins: filteredPins,
       pagination,
-      totalCount,
     }
   }
 }

--- a/libs/services/src/validation/pin-query.test.ts
+++ b/libs/services/src/validation/pin-query.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { pinListInputSchema, tagListInputSchema } from './pin-query.js'
+
+describe('pinListInputSchema', () => {
+  it('parses empty input', () => {
+    expect(pinListInputSchema.parse({})).toEqual({})
+  })
+
+  it('accepts a fully typed input', () => {
+    const result = pinListInputSchema.parse({
+      tag: 'js',
+      search: 'react',
+      readLater: true,
+      noTags: false,
+      sortBy: 'title',
+      sortDirection: 'asc',
+      page: 2,
+      pageSize: 10,
+    })
+    expect(result).toEqual({
+      tag: 'js',
+      search: 'react',
+      readLater: true,
+      noTags: false,
+      sortBy: 'title',
+      sortDirection: 'asc',
+      page: 2,
+      pageSize: 10,
+    })
+  })
+
+  it('rejects stringified booleans', () => {
+    expect(pinListInputSchema.safeParse({ readLater: 'true' }).success).toBe(
+      false
+    )
+  })
+
+  it('rejects stringified numbers', () => {
+    expect(pinListInputSchema.safeParse({ page: '2' }).success).toBe(false)
+  })
+
+  it('rejects invalid sortBy', () => {
+    expect(pinListInputSchema.safeParse({ sortBy: 'bogus' }).success).toBe(
+      false
+    )
+  })
+
+  it('rejects pageSize over 100', () => {
+    expect(pinListInputSchema.safeParse({ pageSize: 500 }).success).toBe(false)
+  })
+
+  it('rejects page < 1', () => {
+    expect(pinListInputSchema.safeParse({ page: 0 }).success).toBe(false)
+  })
+
+  it('rejects empty tag string', () => {
+    expect(pinListInputSchema.safeParse({ tag: '   ' }).success).toBe(false)
+  })
+})
+
+describe('tagListInputSchema', () => {
+  it('accepts withCounts as boolean', () => {
+    expect(tagListInputSchema.parse({ withCounts: true }).withCounts).toBe(true)
+  })
+
+  it('rejects stringified boolean', () => {
+    expect(tagListInputSchema.safeParse({ withCounts: 'true' }).success).toBe(
+      false
+    )
+  })
+
+  it('accepts empty input', () => {
+    expect(tagListInputSchema.parse({})).toEqual({})
+  })
+})

--- a/libs/services/src/validation/pin-query.ts
+++ b/libs/services/src/validation/pin-query.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod'
+
+/**
+ * Canonical typed-JSON schemas for pin/tag list input.
+ *
+ * These schemas represent the "logical" shape of list-query input after
+ * any transport-specific decoding (e.g. REST query-string coercion) has
+ * already happened. Services, MCP tool handlers, and any other caller
+ * should hand these schemas values with native types — booleans as
+ * booleans, numbers as numbers.
+ */
+
+export const pinListInputSchema = z.object({
+  tag: z.string().trim().min(1).optional(),
+  search: z.string().trim().min(1).optional(),
+  readLater: z.boolean().optional(),
+  noTags: z.boolean().optional(),
+  sortBy: z.enum(['created', 'title']).optional(),
+  sortDirection: z.enum(['asc', 'desc']).optional(),
+  page: z.number().int().min(1).optional(),
+  pageSize: z.number().int().min(1).max(100).optional(),
+})
+
+export type PinListInput = z.infer<typeof pinListInputSchema>
+
+export const tagListInputSchema = z.object({
+  withCounts: z.boolean().optional(),
+})
+
+export type TagListInput = z.infer<typeof tagListInputSchema>

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "pnpm": {
     "overrides": {
-      "axios": ">=1.13.5"
+      "axios": ">=1.15.0"
     }
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  axios: '>=1.13.5'
+  axios: '>=1.15.0'
 
 importers:
 
@@ -40,8 +40,8 @@ importers:
   apps/hono:
     dependencies:
       '@hono/node-server':
-        specifier: ^1.19.12
-        version: 1.19.12(hono@4.12.11)
+        specifier: ^1.19.13
+        version: 1.19.13(hono@4.12.12)
       '@pinsquirrel/adapters':
         specifier: workspace:*
         version: link:../../libs/adapters
@@ -67,8 +67,8 @@ importers:
         specifier: ^0.45.2
         version: 0.45.2(@types/pg@8.15.5)(mysql2@3.20.0(@types/node@24.12.2))(pg@8.16.3)
       hono:
-        specifier: ^4.12.11
-        version: 4.12.11
+        specifier: ^4.12.12
+        version: 4.12.12
       mailgun.js:
         specifier: ^12.7.1
         version: 12.7.1
@@ -108,7 +108,7 @@ importers:
         version: 4.2.2
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.3)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -817,8 +817,8 @@ packages:
     resolution: {integrity: sha512-ejvBr8MQCbVsWNZnCwDXjUKq40MDmHalq7cJ6e9s/qzTUFIIo/afzt1Vui9T97FM/V/pN4YsFVoed5NIa96RDg==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@hono/node-server@1.19.12':
-    resolution: {integrity: sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==}
+  '@hono/node-server@1.19.13':
+    resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
@@ -1369,8 +1369,8 @@ packages:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
     engines: {node: '>= 6.0.0'}
 
-  axios@1.14.0:
-    resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -1887,8 +1887,8 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.11:
-    resolution: {integrity: sha512-r4xbIa3mGGGoH9nN4A14DOg2wx7y2oQyJEb5O57C/xzETG/qx4c7CVDQ5WMeKHZ7ORk2W0hZ/sQKXTav3cmYBA==}
+  hono@4.12.12:
+    resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -2282,8 +2282,8 @@ packages:
       yaml:
         optional: true
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.9:
+    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -2508,6 +2508,10 @@ packages:
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
   tinyrainbow@3.1.0:
@@ -3016,9 +3020,9 @@ snapshots:
       '@eslint/core': 1.2.0
       levn: 0.4.1
 
-  '@hono/node-server@1.19.12(hono@4.12.11)':
+  '@hono/node-server@1.19.13(hono@4.12.12)':
     dependencies:
-      hono: 4.12.11
+      hono: 4.12.12
 
   '@humanfs/core@0.19.1': {}
 
@@ -3501,7 +3505,7 @@ snapshots:
 
   aws-ssl-profiles@1.1.2: {}
 
-  axios@1.14.0:
+  axios@1.15.0:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5
@@ -4005,7 +4009,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.11: {}
+  hono@4.12.12: {}
 
   html-escaper@2.0.2: {}
 
@@ -4183,7 +4187,7 @@ snapshots:
 
   mailgun.js@12.7.1:
     dependencies:
-      axios: 1.14.0
+      axios: 1.15.0
       base-64: 1.0.0
       url-join: 4.0.1
     transitivePeerDependencies:
@@ -4370,16 +4374,16 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(yaml@2.8.3):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.6.1
-      postcss: 8.5.8
+      postcss: 8.5.9
       tsx: 4.21.0
       yaml: 2.8.3
 
-  postcss@8.5.8:
+  postcss@8.5.9:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -4596,6 +4600,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tinyrainbow@3.1.0: {}
 
   tree-kill@1.2.2: {}
@@ -4608,7 +4617,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.3):
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -4619,7 +4628,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(yaml@2.8.3)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(yaml@2.8.3)
       resolve-from: 5.0.0
       rollup: 4.60.1
       source-map: 0.7.6
@@ -4628,7 +4637,7 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.8
+      postcss: 8.5.9
       typescript: 6.0.2
     transitivePeerDependencies:
       - jiti
@@ -4689,9 +4698,9 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.8
+      postcss: 8.5.9
       rollup: 4.60.1
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 24.12.2
       fsevents: 2.3.3


### PR DESCRIPTION
Adds a public JSON API exposing user pins and tags to third-party clients via Bearer token (or X-API-Key) authentication backed by the existing ApiKeyService. Endpoints cover listing/fetching pins, listing tags (with optional pin counts), and listing pins by tag id. Private pins are excluded from all responses since API key holders cannot re-authenticate.

The existing session-authenticated /api/metadata and /api/check-url helpers (used only by the HTMX frontend) move to /api/internal to free the /api namespace for the public API.

Query/filter validation lives in @pinsquirrel/services as typed-JSON Zod schemas (pinListInputSchema, tagListInputSchema) so the upcoming MCP tools in Phase 3b can reuse them without duplication. The REST route owns a tiny coerceQuery helper that converts HTTP query strings into the canonical typed shape before validation, keeping services free of transport concerns.

Also adds totalCount as a first-class field on the Pagination domain class (previously returned as a sibling from PinService) so API responses can be built directly from the pagination object.