### PR TITLE
refactor(api): return domain entities directly, matching MCP serializ…

### DIFF
--- a/apps/hono/src/routes/api-v1.test.ts
+++ b/apps/hono/src/routes/api-v1.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { Hono } from 'hono'
-import type { ApiKey, Pin, Tag, User } from '@pinsquirrel/domain'
+import type { ApiKey, Pin, Tag, TagWithCount, User } from '@pinsquirrel/domain'
 import { Pagination } from '@pinsquirrel/domain'
 
 const mockAuthenticateByKey = vi.fn()
@@ -143,7 +143,7 @@ describe('api-v1 routes', () => {
       mockFindUserById.mockResolvedValue(testUser)
     })
 
-    it('returns data and pagination shape', async () => {
+    it('returns pins and pagination shape', async () => {
       mockGetUserPinsWithPagination.mockResolvedValue({
         pins: [makePin()],
         pagination: Pagination.fromTotalCount(1, { page: 1, pageSize: 25 }),
@@ -153,10 +153,10 @@ describe('api-v1 routes', () => {
       })
       expect(res.status).toBe(200)
       const body = (await res.json()) as {
-        data: unknown[]
+        pins: unknown[]
         pagination: { totalCount: number; page: number; hasNext: boolean }
       }
-      expect(body.data).toHaveLength(1)
+      expect(body.pins).toHaveLength(1)
       expect(body.pagination.totalCount).toBe(1)
       expect(body.pagination.page).toBe(1)
       expect(body.pagination.hasNext).toBe(false)
@@ -208,8 +208,8 @@ describe('api-v1 routes', () => {
         headers: { Authorization: 'Bearer ps_ok' },
       })
       expect(res.status).toBe(200)
-      const body = (await res.json()) as { data: { id: string } }
-      expect(body.data.id).toBe('pin-1')
+      const body = (await res.json()) as { id: string }
+      expect(body.id).toBe('pin-1')
     })
 
     it('returns 404 for private pins', async () => {
@@ -233,8 +233,8 @@ describe('api-v1 routes', () => {
         headers: { Authorization: 'Bearer ps_ok' },
       })
       expect(res.status).toBe(200)
-      const body = (await res.json()) as { data: { name: string }[] }
-      expect(body.data[0].name).toBe('foo')
+      const body = (await res.json()) as Tag[]
+      expect(body[0].name).toBe('foo')
     })
 
     it('returns tags with counts when withCounts=true', async () => {
@@ -245,8 +245,8 @@ describe('api-v1 routes', () => {
         headers: { Authorization: 'Bearer ps_ok' },
       })
       expect(res.status).toBe(200)
-      const body = (await res.json()) as { data: { pinCount: number }[] }
-      expect(body.data[0].pinCount).toBe(5)
+      const body = (await res.json()) as TagWithCount[]
+      expect(body[0].pinCount).toBe(5)
     })
   })
 

--- a/apps/hono/src/routes/api-v1.ts
+++ b/apps/hono/src/routes/api-v1.ts
@@ -1,13 +1,11 @@
 import { Hono, type Context } from 'hono'
 import {
   AccessControl,
-  Pagination,
   PinNotFoundError,
   TagNotFoundError,
   UnauthorizedPinAccessError,
   UnauthorizedTagAccessError,
   ValidationError,
-  type Pin,
   type PinFilter,
 } from '@pinsquirrel/domain'
 import {
@@ -71,30 +69,6 @@ function pinFilterFromInput(input: PinListInput): PinFilter {
   }
 }
 
-function serializePin(pin: Pin) {
-  return {
-    id: pin.id,
-    url: pin.url,
-    title: pin.title,
-    description: pin.description,
-    readLater: pin.readLater,
-    tags: pin.tagNames,
-    createdAt: pin.createdAt.toISOString(),
-    updatedAt: pin.updatedAt.toISOString(),
-  }
-}
-
-function serializePagination(p: Pagination) {
-  return {
-    page: p.page,
-    pageSize: p.pageSize,
-    totalCount: p.totalCount,
-    totalPages: p.totalPages,
-    hasNext: p.hasNext,
-    hasPrevious: p.hasPrevious,
-  }
-}
-
 // GET /api/v1/pins - list pins (excludes private pins)
 apiV1.get('/pins', async (c) => {
   const user = getApiUser(c)
@@ -114,10 +88,7 @@ apiV1.get('/pins', async (c) => {
       pinFilterFromInput(input),
       { page: input.page, pageSize: input.pageSize }
     )
-    return c.json({
-      data: result.pins.map(serializePin),
-      pagination: serializePagination(result.pagination),
-    })
+    return c.json(result)
   } catch (err) {
     return errorResponse(c, err)
   }
@@ -134,7 +105,7 @@ apiV1.get('/pins/:id', async (c) => {
     if (pin.isPrivate) {
       return c.json({ error: 'Pin not found' }, 404)
     }
-    return c.json({ data: serializePin(pin) })
+    return c.json(pin)
   } catch (err) {
     return errorResponse(c, err)
   }
@@ -153,27 +124,10 @@ apiV1.get('/tags', async (c) => {
   }
 
   try {
-    if (parsed.data.withCounts) {
-      const tags = await tagService.getUserTagsWithCount(ac, user.id)
-      return c.json({
-        data: tags.map((t) => ({
-          id: t.id,
-          name: t.name,
-          pinCount: t.pinCount,
-          createdAt: t.createdAt.toISOString(),
-          updatedAt: t.updatedAt.toISOString(),
-        })),
-      })
-    }
-    const tags = await tagService.getUserTags(ac, user.id)
-    return c.json({
-      data: tags.map((t) => ({
-        id: t.id,
-        name: t.name,
-        createdAt: t.createdAt.toISOString(),
-        updatedAt: t.updatedAt.toISOString(),
-      })),
-    })
+    const tags = parsed.data.withCounts
+      ? await tagService.getUserTagsWithCount(ac, user.id)
+      : await tagService.getUserTags(ac, user.id)
+    return c.json(tags)
   } catch (err) {
     return errorResponse(c, err)
   }
@@ -204,10 +158,7 @@ apiV1.get('/tags/:id/pins', async (c) => {
       { ...pinFilterFromInput(input), tag: tag.name },
       { page: input.page, pageSize: input.pageSize }
     )
-    return c.json({
-      data: result.pins.map(serializePin),
-      pagination: serializePagination(result.pagination),
-    })
+    return c.json(result)
   } catch (err) {
     return errorResponse(c, err)
   }


### PR DESCRIPTION
…ation

Remove custom serializePin/serializePagination functions and inline tag serialization from the REST API. Domain entities are now returned directly via c.json(), consistent with how the MCP endpoints use JSON.stringify().