### PR TITLE
refactor: anchor wire schemas to domain types and consolidate API wrappers

### DIFF
--- a/apps/hono/src/mcp/auth.ts
+++ b/apps/hono/src/mcp/auth.ts
@@ -1,7 +1,6 @@
 import type { MiddlewareHandler } from 'hono'
 import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js'
-import { apiKeyService } from '../lib/services.js'
-import { userRepository } from '../lib/db.js'
+import { authenticateBearer } from '../middleware/bearer-auth.js'
 
 declare module 'hono' {
   interface ContextVariableMap {
@@ -11,34 +10,16 @@ declare module 'hono' {
 
 export function mcpAuth(): MiddlewareHandler {
   return async (c, next) => {
-    const authHeader = c.req.header('Authorization')
-    if (!authHeader) {
-      return c.json({ error: 'Missing API key' }, 401)
+    const result = await authenticateBearer(c, { allowApiKeyHeader: false })
+    if (!result.ok) {
+      return c.json({ error: result.failure.message }, 401)
     }
-
-    const match = /^Bearer\s+(.+)$/i.exec(authHeader.trim())
-    if (!match) {
-      return c.json({ error: 'Invalid Authorization header' }, 401)
-    }
-
-    const rawKey = match[1].trim()
-    const apiKey = await apiKeyService.authenticateByKey(rawKey)
-    if (!apiKey) {
-      return c.json({ error: 'Invalid API key' }, 401)
-    }
-
-    const user = await userRepository.findById(apiKey.userId)
-    if (!user) {
-      return c.json({ error: 'User not found' }, 401)
-    }
-
     c.set('auth', {
-      token: rawKey,
-      clientId: user.id,
+      token: result.auth.rawKey,
+      clientId: result.auth.user.id,
       scopes: [],
-      extra: { user },
+      extra: { user: result.auth.user },
     })
-
     await next()
   }
 }

--- a/apps/hono/src/mcp/errors.ts
+++ b/apps/hono/src/mcp/errors.ts
@@ -1,0 +1,37 @@
+import {
+  PinNotFoundError,
+  TagNotFoundError,
+  UnauthorizedPinAccessError,
+  UnauthorizedTagAccessError,
+  ValidationError,
+} from '@pinsquirrel/domain'
+
+/**
+ * Map a thrown domain error to an MCP `CallToolResult` with `isError: true`.
+ *
+ * Mirrors the REST `errorResponse` helper in `routes/api-v1.ts`, but produces
+ * structured MCP content instead of an HTTP status. Unknown errors collapse
+ * to a generic message so internal details do not leak to the agent.
+ */
+export function mapDomainErrorToMcp(err: unknown) {
+  let message: string
+  if (err instanceof ValidationError) {
+    message = 'Invalid request'
+  } else if (
+    err instanceof PinNotFoundError ||
+    err instanceof TagNotFoundError
+  ) {
+    message = err.message
+  } else if (
+    err instanceof UnauthorizedPinAccessError ||
+    err instanceof UnauthorizedTagAccessError
+  ) {
+    message = 'Unauthorized'
+  } else {
+    message = 'Internal server error'
+  }
+  return {
+    content: [{ type: 'text' as const, text: message }],
+    isError: true,
+  }
+}

--- a/apps/hono/src/mcp/server.ts
+++ b/apps/hono/src/mcp/server.ts
@@ -1,13 +1,15 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StreamableHTTPTransport } from '@hono/mcp'
-import { AccessControl, type User, type PinFilter } from '@pinsquirrel/domain'
+import { AccessControl, PinNotFoundError, type User } from '@pinsquirrel/domain'
 import {
   pinListInputSchema,
   pinGetInputSchema,
   tagListInputSchema,
+  pinFilterFromInput,
   type PinListInput,
 } from '@pinsquirrel/services'
 import { pinService, tagService } from '../lib/services.js'
+import { mapDomainErrorToMcp } from './errors.js'
 
 function getUserFromExtra(extra: {
   authInfo?: { extra?: Record<string, unknown> }
@@ -30,24 +32,20 @@ server.registerTool(
     annotations: { readOnlyHint: true },
   },
   async (args, extra) => {
-    const user = getUserFromExtra(extra)
-    const ac = new AccessControl(user)
-    const input = args as PinListInput
-    const filter: PinFilter = {
-      isPrivate: false,
-      tag: input.tag,
-      search: input.search,
-      readLater: input.readLater,
-      noTags: input.noTags,
-      sortBy: input.sortBy,
-      sortDirection: input.sortDirection,
-    }
-    const result = await pinService.getUserPinsWithPagination(ac, filter, {
-      page: input.page,
-      pageSize: input.pageSize,
-    })
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+    try {
+      const user = getUserFromExtra(extra)
+      const ac = new AccessControl(user)
+      const input = args as PinListInput
+      const result = await pinService.getUserPinsWithPagination(
+        ac,
+        { ...pinFilterFromInput(input), isPrivate: false },
+        { page: input.page, pageSize: input.pageSize }
+      )
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+      }
+    } catch (err) {
+      return mapDomainErrorToMcp(err)
     }
   }
 )
@@ -61,17 +59,18 @@ server.registerTool(
     annotations: { readOnlyHint: true },
   },
   async ({ id }, extra) => {
-    const user = getUserFromExtra(extra)
-    const ac = new AccessControl(user)
-    const pin = await pinService.getPin(ac, id)
-    if (pin.isPrivate) {
-      return {
-        content: [{ type: 'text' as const, text: 'Pin not found' }],
-        isError: true,
+    try {
+      const user = getUserFromExtra(extra)
+      const ac = new AccessControl(user)
+      const pin = await pinService.getPin(ac, id)
+      if (pin.isPrivate) {
+        return mapDomainErrorToMcp(new PinNotFoundError(id))
       }
-    }
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(pin) }],
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(pin) }],
+      }
+    } catch (err) {
+      return mapDomainErrorToMcp(err)
     }
   }
 )
@@ -85,13 +84,17 @@ server.registerTool(
     annotations: { readOnlyHint: true },
   },
   async ({ withCounts }, extra) => {
-    const user = getUserFromExtra(extra)
-    const ac = new AccessControl(user)
-    const tags = withCounts
-      ? await tagService.getUserTagsWithCount(ac, user.id)
-      : await tagService.getUserTags(ac, user.id)
-    return {
-      content: [{ type: 'text' as const, text: JSON.stringify(tags) }],
+    try {
+      const user = getUserFromExtra(extra)
+      const ac = new AccessControl(user)
+      const tags = withCounts
+        ? await tagService.getUserTagsWithCount(ac, user.id)
+        : await tagService.getUserTags(ac, user.id)
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(tags) }],
+      }
+    } catch (err) {
+      return mapDomainErrorToMcp(err)
     }
   }
 )

--- a/apps/hono/src/middleware/api-auth.ts
+++ b/apps/hono/src/middleware/api-auth.ts
@@ -1,7 +1,6 @@
 import type { Context, MiddlewareHandler } from 'hono'
 import type { ApiKey, User } from '@pinsquirrel/domain'
-import { apiKeyService } from '../lib/services'
-import { userRepository } from '../lib/db'
+import { authenticateBearer } from './bearer-auth.js'
 
 interface ApiAuthVariables {
   apiUser: User
@@ -13,37 +12,14 @@ declare module 'hono' {
   interface ContextVariableMap extends ApiAuthVariables {}
 }
 
-function extractRawKey(c: Context): string | null {
-  const authHeader = c.req.header('Authorization')
-  if (authHeader) {
-    const match = /^Bearer\s+(.+)$/i.exec(authHeader.trim())
-    if (match) return match[1].trim()
-  }
-  const xApiKey = c.req.header('X-API-Key')
-  if (xApiKey) return xApiKey.trim()
-  return null
-}
-
 export function apiKeyAuth(): MiddlewareHandler {
   return async (c, next) => {
-    const rawKey = extractRawKey(c)
-    if (!rawKey) {
-      return c.json({ error: 'Missing API key' }, 401)
+    const result = await authenticateBearer(c, { allowApiKeyHeader: true })
+    if (!result.ok) {
+      return c.json({ error: result.failure.message }, 401)
     }
-
-    const apiKey = await apiKeyService.authenticateByKey(rawKey)
-    if (!apiKey) {
-      return c.json({ error: 'Invalid API key' }, 401)
-    }
-
-    const user = await userRepository.findById(apiKey.userId)
-    if (!user) {
-      return c.json({ error: 'User not found' }, 401)
-    }
-
-    c.set('apiUser', user)
-    c.set('apiKey', apiKey)
-
+    c.set('apiUser', result.auth.user)
+    c.set('apiKey', result.auth.apiKey)
     await next()
   }
 }

--- a/apps/hono/src/middleware/bearer-auth.ts
+++ b/apps/hono/src/middleware/bearer-auth.ts
@@ -1,0 +1,76 @@
+import type { Context } from 'hono'
+import type { ApiKey, User } from '@pinsquirrel/domain'
+import { apiKeyService } from '../lib/services.js'
+import { userRepository } from '../lib/db.js'
+
+export interface AuthenticatedRequest {
+  user: User
+  apiKey: ApiKey
+  rawKey: string
+}
+
+export type AuthFailure =
+  | { reason: 'missing'; message: 'Missing API key' }
+  | { reason: 'invalid'; message: 'Invalid API key' }
+  | { reason: 'invalid_header'; message: 'Invalid Authorization header' }
+  | { reason: 'no_user'; message: 'User not found' }
+
+function extractRawKey(
+  c: Context,
+  options: { allowApiKeyHeader: boolean }
+): { rawKey: string } | { failure: AuthFailure } {
+  const authHeader = c.req.header('Authorization')
+  if (authHeader) {
+    const match = /^Bearer\s+(.+)$/i.exec(authHeader.trim())
+    if (match) return { rawKey: match[1].trim() }
+    if (!options.allowApiKeyHeader) {
+      return {
+        failure: {
+          reason: 'invalid_header',
+          message: 'Invalid Authorization header',
+        },
+      }
+    }
+  }
+  if (options.allowApiKeyHeader) {
+    const xApiKey = c.req.header('X-API-Key')
+    if (xApiKey) return { rawKey: xApiKey.trim() }
+  }
+  return { failure: { reason: 'missing', message: 'Missing API key' } }
+}
+
+/**
+ * Authenticate a request via API key (Bearer token, optionally `X-API-Key`).
+ *
+ * Returns the resolved `User` and `ApiKey` on success, or a structured
+ * `AuthFailure` describing what went wrong. Callers (REST middleware,
+ * MCP middleware) decide how to render the failure as an HTTP response
+ * and what context variables to set on success.
+ */
+export async function authenticateBearer(
+  c: Context,
+  options: { allowApiKeyHeader: boolean } = { allowApiKeyHeader: true }
+): Promise<
+  { ok: true; auth: AuthenticatedRequest } | { ok: false; failure: AuthFailure }
+> {
+  const extracted = extractRawKey(c, options)
+  if ('failure' in extracted) return { ok: false, failure: extracted.failure }
+
+  const apiKey = await apiKeyService.authenticateByKey(extracted.rawKey)
+  if (!apiKey) {
+    return {
+      ok: false,
+      failure: { reason: 'invalid', message: 'Invalid API key' },
+    }
+  }
+
+  const user = await userRepository.findById(apiKey.userId)
+  if (!user) {
+    return {
+      ok: false,
+      failure: { reason: 'no_user', message: 'User not found' },
+    }
+  }
+
+  return { ok: true, auth: { user, apiKey, rawKey: extracted.rawKey } }
+}

--- a/apps/hono/src/routes/api-v1.test.ts
+++ b/apps/hono/src/routes/api-v1.test.ts
@@ -1,15 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { Hono } from 'hono'
 import type { ApiKey, Pin, Tag, TagWithCount, User } from '@pinsquirrel/domain'
-import { Pagination } from '@pinsquirrel/domain'
+import { Pagination, TagNotFoundError } from '@pinsquirrel/domain'
 
 const mockAuthenticateByKey = vi.fn()
 const mockFindUserById = vi.fn()
-const mockFindTagById = vi.fn()
 const mockGetPin = vi.fn()
 const mockGetUserPinsWithPagination = vi.fn()
 const mockGetUserTags = vi.fn()
 const mockGetUserTagsWithCount = vi.fn()
+const mockGetUserTagById = vi.fn()
 
 vi.mock('../lib/services', () => ({
   apiKeyService: {
@@ -25,15 +25,14 @@ vi.mock('../lib/services', () => ({
     getUserTags: (...args: unknown[]) => mockGetUserTags(...args) as unknown,
     getUserTagsWithCount: (...args: unknown[]) =>
       mockGetUserTagsWithCount(...args) as unknown,
+    getUserTagById: (...args: unknown[]) =>
+      mockGetUserTagById(...args) as unknown,
   },
 }))
 
 vi.mock('../lib/db', () => ({
   userRepository: {
     findById: (...args: unknown[]) => mockFindUserById(...args) as unknown,
-  },
-  tagRepository: {
-    findById: (...args: unknown[]) => mockFindTagById(...args) as unknown,
   },
 }))
 
@@ -258,7 +257,7 @@ describe('api-v1 routes', () => {
     })
 
     it('returns pins filtered by tag name', async () => {
-      mockFindTagById.mockResolvedValue(makeTag())
+      mockGetUserTagById.mockResolvedValue(makeTag())
       mockGetUserPinsWithPagination.mockResolvedValue({
         pins: [makePin()],
         pagination: Pagination.fromTotalCount(1),
@@ -275,16 +274,10 @@ describe('api-v1 routes', () => {
       expect(filter.isPrivate).toBeUndefined()
     })
 
-    it('returns 404 if tag does not belong to user', async () => {
-      mockFindTagById.mockResolvedValue(makeTag({ userId: 'other-user' }))
-      const res = await app.request('/api/v1/tags/tag-1/pins', {
-        headers: { Authorization: 'Bearer ps_ok' },
-      })
-      expect(res.status).toBe(404)
-    })
-
-    it('returns 404 when tag not found', async () => {
-      mockFindTagById.mockResolvedValue(null)
+    it('returns 404 when tag service throws TagNotFoundError', async () => {
+      mockGetUserTagById.mockRejectedValue(
+        new TagNotFoundError('Tag with ID "tag-1" not found')
+      )
       const res = await app.request('/api/v1/tags/tag-1/pins', {
         headers: { Authorization: 'Bearer ps_ok' },
       })

--- a/apps/hono/src/routes/api-v1.ts
+++ b/apps/hono/src/routes/api-v1.ts
@@ -7,7 +7,6 @@ import {
   UnauthorizedPinAccessError,
   UnauthorizedTagAccessError,
   ValidationError,
-  type PinFilter,
 } from '@pinsquirrel/domain'
 import {
   pinListQuerySchema,
@@ -17,10 +16,9 @@ import {
   tagWithCountSchema,
   paginatedPinsSchema,
   errorSchema,
-  type PinListInput,
+  pinFilterFromInput,
 } from '@pinsquirrel/services'
 import { pinService, tagService } from '../lib/services'
-import { tagRepository } from '../lib/db'
 import { apiKeyAuth, getApiUser } from '../middleware/api-auth'
 
 const apiV1 = new OpenAPIHono()
@@ -176,18 +174,6 @@ function firstIssue(issues: { message: string }[]): string {
   return issues[0]?.message ?? 'Invalid query'
 }
 
-function pinFilterFromInput(input: PinListInput): PinFilter {
-  return {
-    isPrivate: input.isPrivate,
-    tag: input.tag,
-    search: input.search,
-    readLater: input.readLater,
-    noTags: input.noTags,
-    sortBy: input.sortBy,
-    sortDirection: input.sortDirection,
-  }
-}
-
 function errorResponse(c: Context, err: unknown) {
   if (err instanceof ValidationError) {
     return c.json({ error: 'Invalid request' }, 400)
@@ -276,11 +262,7 @@ apiV1.get('/tags/:id/pins', async (c) => {
   const input = parsed.data
 
   try {
-    const tag = await tagRepository.findById(tagId)
-    if (!tag || tag.userId !== user.id) {
-      return c.json({ error: 'Tag not found' }, 404)
-    }
-
+    const tag = await tagService.getUserTagById(ac, tagId)
     const result = await pinService.getUserPinsWithPagination(
       ac,
       { ...pinFilterFromInput(input), tag: tag.name },

--- a/libs/domain/src/index.ts
+++ b/libs/domain/src/index.ts
@@ -26,6 +26,9 @@ export type { ApiKey, CreateApiKeyData } from './entities/api-key.js'
 export { Pagination, type PaginationOptions } from './entities/pagination.js'
 export { AccessControl, type AccessGateable } from './entities/access.js'
 
+// Type utilities
+export type { Jsonify } from './jsonify.js'
+
 // Interfaces
 export type { Repository } from './interfaces/repository.js'
 export type { UserRepository } from './interfaces/user-repository.js'

--- a/libs/domain/src/jsonify.ts
+++ b/libs/domain/src/jsonify.ts
@@ -1,0 +1,18 @@
+/**
+ * Recursively converts a domain type to its JSON wire-format equivalent.
+ *
+ * `JSON.stringify` produces ISO 8601 strings for Date values; this type
+ * mirrors that conversion so wire-format schemas (e.g. OpenAPI response
+ * schemas) can be compile-time anchored to their domain counterparts.
+ */
+export type Jsonify<T> = T extends Date
+  ? string
+  : T extends null
+    ? null
+    : T extends undefined
+      ? undefined
+      : T extends Array<infer U>
+        ? Array<Jsonify<U>>
+        : T extends object
+          ? { [K in keyof T]: Jsonify<T[K]> }
+          : T

--- a/libs/services/src/index.ts
+++ b/libs/services/src/index.ts
@@ -11,6 +11,7 @@ export {
   pinListInputSchema,
   pinGetInputSchema,
   tagListInputSchema,
+  pinFilterFromInput,
   type PinListInput,
   type TagListInput,
 } from './validation/pin-query.js'

--- a/libs/services/src/services/tag.test.ts
+++ b/libs/services/src/services/tag.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { TagService } from './tag.js'
+import type { TagRepository, Tag, User } from '@pinsquirrel/domain'
+import { AccessControl, Role, TagNotFoundError } from '@pinsquirrel/domain'
+
+describe('TagService.getUserTagById', () => {
+  let service: TagService
+  let mockRepo: TagRepository
+
+  const owner: User = {
+    id: 'owner-id',
+    username: 'owner',
+    passwordHash: 'x',
+    emailHash: null,
+    roles: [Role.User],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  }
+
+  const otherUser: User = {
+    ...owner,
+    id: 'other-id',
+    username: 'other',
+  }
+
+  const tag: Tag = {
+    id: 'tag-1',
+    userId: 'owner-id',
+    name: 'foo',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  }
+
+  beforeEach(() => {
+    mockRepo = {
+      findById: vi.fn(),
+      findByUserId: vi.fn(),
+      findByUserIdAndName: vi.fn(),
+      fetchOrCreateByNames: vi.fn(),
+      findByUserIdWithPinCount: vi.fn(),
+      mergeTags: vi.fn(),
+      deleteTagsWithNoPins: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    } as unknown as TagRepository
+    service = new TagService(mockRepo)
+  })
+
+  it('returns the tag when owned by the caller', async () => {
+    vi.mocked(mockRepo.findById).mockResolvedValue(tag)
+    const ac = new AccessControl(owner)
+    await expect(service.getUserTagById(ac, 'tag-1')).resolves.toEqual(tag)
+  })
+
+  it('throws TagNotFoundError when the tag does not exist', async () => {
+    vi.mocked(mockRepo.findById).mockResolvedValue(null)
+    const ac = new AccessControl(owner)
+    await expect(service.getUserTagById(ac, 'tag-1')).rejects.toBeInstanceOf(
+      TagNotFoundError
+    )
+  })
+
+  it('throws TagNotFoundError when the tag belongs to a different user', async () => {
+    vi.mocked(mockRepo.findById).mockResolvedValue(tag)
+    const ac = new AccessControl(otherUser)
+    await expect(service.getUserTagById(ac, 'tag-1')).rejects.toBeInstanceOf(
+      TagNotFoundError
+    )
+  })
+
+  it('throws TagNotFoundError for unauthenticated callers', async () => {
+    vi.mocked(mockRepo.findById).mockResolvedValue(tag)
+    const ac = new AccessControl(null)
+    await expect(service.getUserTagById(ac, 'tag-1')).rejects.toBeInstanceOf(
+      TagNotFoundError
+    )
+  })
+})

--- a/libs/services/src/services/tag.ts
+++ b/libs/services/src/services/tag.ts
@@ -29,6 +29,19 @@ export class TagService {
   }
 
   /**
+   * Get a single tag owned by the authenticated user.
+   * Throws `TagNotFoundError` when the tag does not exist or the caller
+   * cannot read it (404-style ownership obfuscation).
+   */
+  async getUserTagById(ac: AccessControl, tagId: string): Promise<Tag> {
+    const tag = await this.tagRepository.findById(tagId)
+    if (!tag || !ac.canRead(tag)) {
+      throw new TagNotFoundError(`Tag with ID "${tagId}" not found`)
+    }
+    return tag
+  }
+
+  /**
    * Get all tags with pin counts for a specified user (filtered through access control)
    * Allows unauthenticated users - they will only see tags they can read (none for now, but future public tags)
    */

--- a/libs/services/src/validation/pin-query.ts
+++ b/libs/services/src/validation/pin-query.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import type { PinFilter } from '@pinsquirrel/domain'
 
 /**
  * Canonical typed-JSON schemas for pin/tag list input.
@@ -44,3 +45,23 @@ export const tagListInputSchema = z.object({
 })
 
 export type TagListInput = z.infer<typeof tagListInputSchema>
+
+/**
+ * Translate a validated `PinListInput` into a domain `PinFilter`.
+ *
+ * Both the REST API and MCP transport accept the same logical input shape,
+ * so the conversion lives here as a single source of truth. Callers that
+ * need to enforce additional constraints (e.g. forcing `isPrivate: false`
+ * for public-only endpoints) should override after calling this helper.
+ */
+export function pinFilterFromInput(input: PinListInput): PinFilter {
+  return {
+    isPrivate: input.isPrivate,
+    tag: input.tag,
+    search: input.search,
+    readLater: input.readLater,
+    noTags: input.noTags,
+    sortBy: input.sortBy,
+    sortDirection: input.sortDirection,
+  }
+}

--- a/libs/services/src/validation/responses.ts
+++ b/libs/services/src/validation/responses.ts
@@ -1,29 +1,33 @@
 import { z } from 'zod'
-import {
-  urlSchema,
-  pinTitleSchema,
-  pinDescriptionSchema,
-  tagNameSchema,
-} from './pin.js'
+import type {
+  Pin,
+  Tag,
+  TagWithCount,
+  Pagination,
+  Jsonify,
+} from '@pinsquirrel/domain'
 
 /**
  * Zod schemas describing the shapes that services return.
  * Used for OpenAPI spec generation and documentation.
  *
- * Dates are represented as ISO 8601 strings because that is the
- * JSON wire format produced by JSON.stringify(Date).
+ * Each schema is anchored to its domain type via `z.ZodType<Jsonify<T>>`,
+ * so adding a field to a domain entity will fail the build here until
+ * the wire-format schema is updated. Dates are represented as ISO 8601
+ * strings because that is the JSON wire format produced by
+ * `JSON.stringify(Date)`.
  */
 
-export const pinSchema = z
+export const pinSchema: z.ZodType<Jsonify<Pin>> = z
   .object({
     id: z.string().describe('Unique pin identifier'),
     userId: z.string().describe('Owner user ID'),
-    url: urlSchema.describe('Bookmarked URL'),
-    title: pinTitleSchema.describe('Pin title'),
-    description: pinDescriptionSchema.describe('Optional description'),
+    url: z.string().describe('Bookmarked URL'),
+    title: z.string().describe('Pin title'),
+    description: z.string().nullable().describe('Optional description'),
     readLater: z.boolean().describe('Marked for reading later'),
     isPrivate: z.boolean().describe('Whether the pin is private'),
-    tagNames: z.array(tagNameSchema).describe('Associated tag names'),
+    tagNames: z.array(z.string()).describe('Associated tag names'),
     createdAt: z.string().datetime().describe('Creation timestamp (ISO 8601)'),
     updatedAt: z
       .string()
@@ -32,7 +36,7 @@ export const pinSchema = z
   })
   .describe('A bookmarked pin')
 
-export const tagSchema = z
+export const tagSchema: z.ZodType<Jsonify<Tag>> = z
   .object({
     id: z.string().describe('Unique tag identifier'),
     userId: z.string().describe('Owner user ID'),
@@ -45,13 +49,21 @@ export const tagSchema = z
   })
   .describe('A tag')
 
-export const tagWithCountSchema = tagSchema
-  .extend({
+export const tagWithCountSchema: z.ZodType<Jsonify<TagWithCount>> = z
+  .object({
+    id: z.string().describe('Unique tag identifier'),
+    userId: z.string().describe('Owner user ID'),
+    name: z.string().describe('Tag name'),
     pinCount: z.number().int().min(0).describe('Number of pins with this tag'),
+    createdAt: z.string().datetime().describe('Creation timestamp (ISO 8601)'),
+    updatedAt: z
+      .string()
+      .datetime()
+      .describe('Last update timestamp (ISO 8601)'),
   })
   .describe('A tag with pin count')
 
-export const paginationSchema = z
+export const paginationSchema: z.ZodType<Jsonify<Pagination>> = z
   .object({
     totalCount: z.number().int().min(0).describe('Total number of results'),
     page: z.number().int().min(1).describe('Current page number'),
@@ -63,7 +75,12 @@ export const paginationSchema = z
   })
   .describe('Pagination metadata')
 
-export const paginatedPinsSchema = z
+export interface PaginatedPins {
+  pins: Pin[]
+  pagination: Pagination
+}
+
+export const paginatedPinsSchema: z.ZodType<Jsonify<PaginatedPins>> = z
   .object({
     pins: z.array(pinSchema).describe('List of pins'),
     pagination: paginationSchema,

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "pnpm": {
     "overrides": {
-      "axios": ">=1.15.0"
+      "axios": ">=1.15.2"
     }
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  axios: '>=1.15.0'
+  axios: '>=1.15.2'
 
 importers:
 
@@ -1454,8 +1454,8 @@ packages:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
     engines: {node: '>= 6.0.0'}
 
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+  axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -1973,8 +1973,8 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -3929,9 +3929,9 @@ snapshots:
 
   aws-ssl-profiles@1.1.2: {}
 
-  axios@1.15.0:
+  axios@1.16.0:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -4462,7 +4462,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   form-data@4.0.5:
     dependencies:
@@ -4742,7 +4742,7 @@ snapshots:
 
   mailgun.js@12.7.1:
     dependencies:
-      axios: 1.15.0
+      axios: 1.16.0
       base-64: 1.0.0
       url-join: 4.0.1
     transitivePeerDependencies:


### PR DESCRIPTION
Make the domain the single source of truth for shapes and remove drift-prone duplication across REST and MCP transports. Specifically:

- Add Jsonify<T> in @pinsquirrel/domain to model JSON wire format (Date → string). Constrain pinSchema, tagSchema, tagWithCountSchema, paginationSchema, and paginatedPinsSchema in responses.ts as z.ZodType<Jsonify<DomainType>>, so adding a domain field fails the build until the OpenAPI schema is updated.
- Move pinFilterFromInput into @pinsquirrel/services so REST and MCP share one definition.
- Extract authenticateBearer helper; api-auth.ts and mcp/auth.ts are now thin wrappers around it.
- Add mapDomainErrorToMcp paralleling REST's errorResponse so MCP tool handlers translate domain errors uniformly instead of inlining ad-hoc isError strings.
- Add tagService.getUserTagById; /tags/:id/pins now goes through the service layer instead of reaching around to tagRepository directly.