### PR TITLE
feat(seo): serve /robots.txt and /sitemap.xml

### DIFF
--- a/apps/hono/src/app.tsx
+++ b/apps/hono/src/app.tsx
@@ -23,6 +23,7 @@ import { importRoutes } from './routes/import'
 import { exportRoutes } from './routes/export'
 import { privateRoutes } from './routes/private'
 import { mcpRoutes } from './routes/mcp'
+import { seoRoutes } from './routes/seo'
 import { sessionMiddleware } from './middleware/session'
 
 // Create the Hono app
@@ -47,6 +48,10 @@ app.use('*', secureHeaders())
 // Serve static files (must run before session middleware so CSS/JS load
 // even if the database is unavailable)
 app.use('/static/*', serveStatic({ root: './src' }))
+
+// SEO endpoints — mounted before session middleware so crawlers can fetch
+// them without a database connection.
+app.route('/', seoRoutes)
 
 app.route('/mcp', mcpRoutes)
 

--- a/apps/hono/src/routes/seo.test.ts
+++ b/apps/hono/src/routes/seo.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+
+import { seoRoutes } from './seo'
+
+describe('SEO Routes', () => {
+  let app: Hono
+
+  beforeEach(() => {
+    app = new Hono()
+    app.route('/', seoRoutes)
+  })
+
+  describe('GET /robots.txt', () => {
+    it('returns 200 with text/plain content type', async () => {
+      const res = await app.request('http://example.com/robots.txt')
+
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-type')).toMatch(/^text\/plain/)
+    })
+
+    it('includes a wildcard User-agent directive', async () => {
+      const res = await app.request('http://example.com/robots.txt')
+      const body = await res.text()
+
+      expect(body).toMatch(/^User-agent:\s*\*/m)
+    })
+
+    it('disallows authenticated user paths', async () => {
+      const res = await app.request('http://example.com/robots.txt')
+      const body = await res.text()
+
+      for (const path of [
+        '/pins',
+        '/tags',
+        '/profile',
+        '/import',
+        '/export',
+        '/private',
+        '/api/',
+        '/mcp',
+        '/reset-password/',
+      ]) {
+        expect(body).toContain(`Disallow: ${path}`)
+      }
+    })
+
+    it('references the sitemap with an absolute URL derived from the request', async () => {
+      const res = await app.request('http://example.com/robots.txt')
+      const body = await res.text()
+
+      expect(body).toContain('Sitemap: http://example.com/sitemap.xml')
+    })
+
+    it('uses the request host so it works on any deployment domain', async () => {
+      const res = await app.request('https://app.pinsquirrel.com/robots.txt')
+      const body = await res.text()
+
+      expect(body).toContain('Sitemap: https://app.pinsquirrel.com/sitemap.xml')
+    })
+  })
+
+  describe('GET /sitemap.xml', () => {
+    it('returns 200 with an XML content type', async () => {
+      const res = await app.request('http://example.com/sitemap.xml')
+
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-type')).toMatch(/xml/)
+    })
+
+    it('declares the sitemap XML namespace', async () => {
+      const res = await app.request('http://example.com/sitemap.xml')
+      const body = await res.text()
+
+      expect(body).toContain(
+        'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"'
+      )
+    })
+
+    it('lists canonical public URLs using the request host', async () => {
+      const res = await app.request('https://app.pinsquirrel.com/sitemap.xml')
+      const body = await res.text()
+
+      expect(body).toContain('<loc>https://app.pinsquirrel.com/</loc>')
+      expect(body).toContain('<loc>https://app.pinsquirrel.com/privacy</loc>')
+      expect(body).toContain('<loc>https://app.pinsquirrel.com/terms</loc>')
+    })
+
+    it('does not list authenticated or token-bound paths', async () => {
+      const res = await app.request('https://app.pinsquirrel.com/sitemap.xml')
+      const body = await res.text()
+
+      for (const path of [
+        '/pins',
+        '/tags',
+        '/profile',
+        '/import',
+        '/export',
+        '/private',
+        '/api/',
+        '/reset-password',
+        '/signout',
+      ]) {
+        expect(body).not.toContain(`<loc>https://app.pinsquirrel.com${path}`)
+      }
+    })
+  })
+})

--- a/apps/hono/src/routes/seo.ts
+++ b/apps/hono/src/routes/seo.ts
@@ -1,0 +1,55 @@
+import { Hono } from 'hono'
+
+const seo = new Hono()
+
+const DISALLOWED_PATHS = [
+  '/pins',
+  '/tags',
+  '/profile',
+  '/import',
+  '/export',
+  '/private',
+  '/api/',
+  '/health',
+  '/mcp',
+  '/signout',
+  '/reset-password/',
+] as const
+
+const PUBLIC_PATHS = ['/', '/privacy', '/terms'] as const
+
+function getOrigin(requestUrl: string): string {
+  const url = new URL(requestUrl)
+  return `${url.protocol}//${url.host}`
+}
+
+seo.get('/robots.txt', (c) => {
+  const origin = getOrigin(c.req.url)
+  const lines = [
+    'User-agent: *',
+    ...DISALLOWED_PATHS.map((p) => `Disallow: ${p}`),
+    '',
+    `Sitemap: ${origin}/sitemap.xml`,
+    '',
+  ]
+  return c.text(lines.join('\n'), 200, {
+    'Content-Type': 'text/plain; charset=utf-8',
+  })
+})
+
+seo.get('/sitemap.xml', (c) => {
+  const origin = getOrigin(c.req.url)
+  const urls = PUBLIC_PATHS.map(
+    (p) => `  <url>\n    <loc>${origin}${p}</loc>\n  </url>`
+  ).join('\n')
+  const body = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>
+`
+  return c.body(body, 200, {
+    'Content-Type': 'application/xml; charset=utf-8',
+  })
+})
+
+export { seo as seoRoutes }


### PR DESCRIPTION
Crawlers can now discover what to index and what to skip. Both endpoints derive their absolute URLs from the request host, so they work in dev and on any deployment domain without env config. Mounted before session middleware so they remain reachable when the database is unavailable.