### PR TITLE
feat(auth): early-access waitlist and user lifecycle states

### DIFF
--- a/apps/hono/package.json
+++ b/apps/hono/package.json
@@ -16,7 +16,8 @@
     "test:watch": "vitest --watch --coverage",
     "test:coverage": "vitest --run --coverage",
     "css:build": "tailwindcss -i ./src/styles/app.css -o ./src/static/styles.css",
-    "css:watch": "tailwindcss -i ./src/styles/app.css -o ./src/static/styles.css --watch"
+    "css:watch": "tailwindcss -i ./src/styles/app.css -o ./src/static/styles.css --watch",
+    "grant-access": "tsx src/scripts/grant-access.ts"
   },
   "dependencies": {
     "@hono/mcp": "^0.2.5",

--- a/apps/hono/src/routes/auth.tsx
+++ b/apps/hono/src/routes/auth.tsx
@@ -4,6 +4,7 @@ import {
   InvalidCredentialsError,
   EmailVerificationRequiredError,
   MissingRoleError,
+  AccessNotGrantedError,
   InvalidResetTokenError,
   ResetTokenExpiredError,
 } from '@pinsquirrel/domain'
@@ -110,6 +111,9 @@ auth.post('/signin', async (c) => {
       errors = { _form: [error.message] }
     } else if (error instanceof MissingRoleError) {
       errors = { _form: [error.message] }
+    } else if (error instanceof AccessNotGrantedError) {
+      // Verified user still waiting on the early-access waitlist
+      errors = { _form: [error.message] }
     } else {
       // Log unexpected errors for debugging
       logger.error({ err: safeError(error) }, 'Signin failed')
@@ -123,7 +127,10 @@ auth.post('/signin', async (c) => {
         username={username}
         keepSignedIn={keepSignedIn}
       />,
-      error instanceof MissingRoleError ? 403 : 400
+      error instanceof MissingRoleError ||
+        error instanceof AccessNotGrantedError
+        ? 403
+        : 400
     )
   }
 })
@@ -172,7 +179,7 @@ auth.post(
         return c.html(
           <SignUpPage
             success={true}
-            message="Your account was created, but we had trouble sending the verification email."
+            message="You're on the waitlist, but we had trouble sending your confirmation email."
             showResendLink={true}
           />
         )
@@ -182,7 +189,7 @@ auth.post(
       return c.html(
         <SignUpPage
           success={true}
-          message="Check your email to set your password and complete registration."
+          message="Check your email to confirm your spot on the early-access waitlist."
         />
       )
     } catch (error) {

--- a/apps/hono/src/scripts/grant-access.ts
+++ b/apps/hono/src/scripts/grant-access.ts
@@ -1,0 +1,61 @@
+import 'dotenv/config'
+import {
+  createDatabaseClient,
+  DrizzleUserRepository,
+} from '@pinsquirrel/database'
+import { AuthenticationService } from '@pinsquirrel/services'
+
+/**
+ * Manually grant a waitlisted user access to the application.
+ *
+ * Usage:
+ *   pnpm --filter @pinsquirrel/hono grant-access <username>
+ *
+ * Moves the user from the early-access waitlist into the active state so they
+ * can sign in. Idempotent: granting an already-active user reports no change.
+ */
+async function main(): Promise<void> {
+  const username = process.argv[2]
+  if (!username) {
+    console.error(
+      'Usage: pnpm --filter @pinsquirrel/hono grant-access <username>'
+    )
+    process.exit(1)
+  }
+
+  const databaseUrl = process.env.DATABASE_URL
+  if (!databaseUrl) {
+    console.error('DATABASE_URL is not set')
+    process.exit(1)
+  }
+
+  const db = createDatabaseClient(databaseUrl)
+  const userRepository = new DrizzleUserRepository(db)
+  const authService = new AuthenticationService(userRepository)
+
+  const user = await userRepository.findByUsername(username)
+  if (!user) {
+    console.error(`User "${username}" not found`)
+    process.exit(1)
+  }
+
+  const previousStatus = user.status
+  const updated = await authService.grantAccess(user.id)
+
+  if (previousStatus === updated.status) {
+    console.log(
+      `No change: "${updated.username}" is already "${updated.status}".`
+    )
+  } else {
+    console.log(
+      `Granted access to "${updated.username}" (${previousStatus} -> ${updated.status}).`
+    )
+  }
+
+  process.exit(0)
+}
+
+main().catch((error: unknown) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/apps/hono/src/views/pages/signup.tsx
+++ b/apps/hono/src/views/pages/signup.tsx
@@ -20,14 +20,18 @@ export const SignUpPage: FC<SignUpPageProps> = ({
   showResendLink = false,
 }) => {
   return (
-    <DefaultLayout title="Sign Up" user={null}>
+    <DefaultLayout title="Request Early Access" user={null}>
       <div class="flex flex-col items-center justify-center px-4 py-16">
         <div class="w-full max-w-md">
           {/* Header */}
           <div class="text-center mb-8">
-            <h1 class="text-3xl font-bold">Join The Digital Squirrel Gang</h1>
+            <h1 class="text-3xl font-bold">Join the Early Access Waitlist</h1>
             <p class="mt-2 text-muted-foreground">
-              Or{' '}
+              PinSquirrel is opening up to new squirrels in batches. Claim your
+              spot and we'll let you in soon.
+            </p>
+            <p class="mt-2 text-muted-foreground">
+              Already in?{' '}
               <a
                 href="/signin"
                 class="text-primary hover:underline font-medium"
@@ -43,7 +47,7 @@ export const SignUpPage: FC<SignUpPageProps> = ({
               // Success state
               <div>
                 <h2 class="text-xl font-bold mb-4 text-green-700 dark:text-green-300">
-                  Account Created!
+                  You're on the list!
                 </h2>
                 {message && (
                   <SuccessMessage message={message} className="mb-4" />
@@ -51,7 +55,7 @@ export const SignUpPage: FC<SignUpPageProps> = ({
                 <p class="text-muted-foreground mb-4">
                   {showResendLink
                     ? 'If you don\u2019t receive an email, you can request a new one.'
-                    : 'We\u2019ve sent you an email with a link to set your password. Check your inbox (and spam folder) and click the link to complete your registration.'}
+                    : 'We\u2019ve sent you an email with a link to confirm your spot and set your password. Check your inbox (and spam folder) and click the link. We\u2019re opening access in batches and will let you in soon.'}
                 </p>
                 {showResendLink && (
                   <a
@@ -79,7 +83,7 @@ export const SignUpPage: FC<SignUpPageProps> = ({
             ) : (
               // Registration form
               <div>
-                <h2 class="text-xl font-bold mb-4">Create Account</h2>
+                <h2 class="text-xl font-bold mb-4">Request Early Access</h2>
 
                 <form
                   method="post"
@@ -137,8 +141,8 @@ export const SignUpPage: FC<SignUpPageProps> = ({
                       </p>
                     )}
                     <p class="text-xs text-muted-foreground">
-                      We'll send you an email to set your password. We hash your
-                      email for privacy.
+                      We'll email you a link to confirm your spot and set your
+                      password. We hash your email for privacy.
                     </p>
                   </div>
 
@@ -151,7 +155,7 @@ export const SignUpPage: FC<SignUpPageProps> = ({
                            active:neobrutalism-shadow-pressed active:translate-x-[2px] active:translate-y-[2px]
                            transition-all disabled:opacity-50 disabled:cursor-not-allowed"
                   >
-                    Create Account
+                    Request Early Access
                   </button>
                 </form>
               </div>

--- a/libs/database/src/migrations/0003_bitter_fat_cobra.sql
+++ b/libs/database/src/migrations/0003_bitter_fat_cobra.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `users` ADD `status` enum('unverified','waitlist','active') DEFAULT 'unverified' NOT NULL;
+--> statement-breakpoint
+-- Backfill: existing users who already set a password are active users.
+-- Users without a password never completed registration, so they remain 'unverified'.
+UPDATE `users` SET `status` = 'active' WHERE `password_hash` IS NOT NULL;

--- a/libs/database/src/migrations/meta/0003_snapshot.json
+++ b/libs/database/src/migrations/meta/0003_snapshot.json
@@ -1,0 +1,572 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "c61217f2-615c-412e-ac91-0ff06600de26",
+  "prevId": "a68fb603-7d5e-4114-a95b-70d97cfd433e",
+  "tables": {
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "api_keys_id": {
+          "name": "api_keys_id",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": ["key_hash"]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "password_reset_tokens_id": {
+          "name": "password_reset_tokens_id",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {
+        "password_reset_tokens_token_hash_unique": {
+          "name": "password_reset_tokens_token_hash_unique",
+          "columns": ["token_hash"]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "pins_tags": {
+      "name": "pins_tags",
+      "columns": {
+        "pin_id": {
+          "name": "pin_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pins_tags_pin_id_pins_id_fk": {
+          "name": "pins_tags_pin_id_pins_id_fk",
+          "tableFrom": "pins_tags",
+          "tableTo": "pins",
+          "columnsFrom": ["pin_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pins_tags_tag_id_tags_id_fk": {
+          "name": "pins_tags_tag_id_tags_id_fk",
+          "tableFrom": "pins_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pins_tags_pin_id_tag_id_pk": {
+          "name": "pins_tags_pin_id_tag_id_pk",
+          "columns": ["pin_id", "tag_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "pins": {
+      "name": "pins",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url_hash": {
+          "name": "url_hash",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "read_later": {
+          "name": "read_later",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_private": {
+          "name": "is_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "pins_user_id_url_hash_idx": {
+          "name": "pins_user_id_url_hash_idx",
+          "columns": ["user_id", "url_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "pins_user_id_users_id_fk": {
+          "name": "pins_user_id_users_id_fk",
+          "tableFrom": "pins",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pins_id": {
+          "name": "pins_id",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "sessions_id": {
+          "name": "sessions_id",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "tags_user_id_name_idx": {
+          "name": "tags_user_id_name_idx",
+          "columns": ["user_id", "name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "tags_user_id_users_id_fk": {
+          "name": "tags_user_id_users_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tags_id": {
+          "name": "tags_id",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "user_roles": {
+      "name": "user_roles",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_user_id_role_pk": {
+          "name": "user_roles_user_id_role_pk",
+          "columns": ["user_id", "role"]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('unverified','waitlist','active')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unverified'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "users_id": {
+          "name": "users_id",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": ["username"]
+        }
+      },
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/libs/database/src/migrations/meta/_journal.json
+++ b/libs/database/src/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1775662600286,
       "tag": "0002_cold_power_pack",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "5",
+      "when": 1782174904882,
+      "tag": "0003_bitter_fat_cobra",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/database/src/repositories/user.test.ts
+++ b/libs/database/src/repositories/user.test.ts
@@ -4,6 +4,7 @@ import type { MySql2Database } from 'drizzle-orm/mysql2'
 import mysql from 'mysql2/promise'
 import type { Pool } from 'mysql2/promise'
 import { DrizzleUserRepository } from './user.js'
+import { UserStatus } from '@pinsquirrel/domain'
 
 describe('DrizzleUserRepository - Integration Tests', () => {
   let testDb: MySql2Database<Record<string, unknown>>
@@ -335,6 +336,22 @@ describe('DrizzleUserRepository - Integration Tests', () => {
       const saved = await repository.findById(result.id)
       expect(saved?.emailHash).toBeNull()
     })
+
+    it('should default new users to unverified status', async () => {
+      const createData = {
+        username: `newuser-${crypto.randomUUID().slice(0, 8)}`,
+        passwordHash: null,
+        emailHash: null,
+      }
+
+      const result = await repository.create(createData)
+
+      expect(result.status).toBe(UserStatus.Unverified)
+
+      // Verify it was actually persisted
+      const saved = await repository.findById(result.id)
+      expect(saved?.status).toBe(UserStatus.Unverified)
+    })
   })
 
   describe('update', () => {
@@ -410,6 +427,18 @@ describe('DrizzleUserRepository - Integration Tests', () => {
       const updated = await repository.findById(existingUserId)
       expect(updated!.passwordHash).toBe('new_hashed_password')
       expect(updated!.emailHash).toBe('new_hashed_email')
+    })
+
+    it('should update user status', async () => {
+      const result = await repository.update(existingUserId, {
+        status: UserStatus.Waitlist,
+      })
+
+      expect(result!.status).toBe(UserStatus.Waitlist)
+
+      // Verify it was actually updated in database
+      const updated = await repository.findById(existingUserId)
+      expect(updated!.status).toBe(UserStatus.Waitlist)
     })
 
     it('should update only updatedAt when no fields provided', async () => {

--- a/libs/database/src/repositories/user.ts
+++ b/libs/database/src/repositories/user.ts
@@ -129,6 +129,11 @@ export class DrizzleUserRepository implements UserRepository {
       updateData.emailHash = data.emailHash
     }
 
+    // Update lifecycle status if provided
+    if (data.status !== undefined) {
+      updateData.status = data.status
+    }
+
     await this.db.update(users).set(updateData).where(eq(users.id, id))
 
     const [updated] = await this.db

--- a/libs/database/src/schema/users.ts
+++ b/libs/database/src/schema/users.ts
@@ -1,10 +1,18 @@
-import { mysqlTable, varchar, timestamp } from 'drizzle-orm/mysql-core'
+import {
+  mysqlTable,
+  varchar,
+  timestamp,
+  mysqlEnum,
+} from 'drizzle-orm/mysql-core'
 
 export const users = mysqlTable('users', {
   id: varchar('id', { length: 36 }).primaryKey(),
   username: varchar('username', { length: 255 }).notNull().unique(),
   passwordHash: varchar('password_hash', { length: 255 }),
   emailHash: varchar('email_hash', { length: 255 }),
+  status: mysqlEnum('status', ['unverified', 'waitlist', 'active'])
+    .default('unverified')
+    .notNull(),
   createdAt: timestamp('created_at', { mode: 'date', fsp: 3 })
     .defaultNow()
     .notNull(),

--- a/libs/domain/src/entities/user-status.ts
+++ b/libs/domain/src/entities/user-status.ts
@@ -1,0 +1,5 @@
+export enum UserStatus {
+  Unverified = 'unverified',
+  Waitlist = 'waitlist',
+  Active = 'active',
+}

--- a/libs/domain/src/entities/user.ts
+++ b/libs/domain/src/entities/user.ts
@@ -1,4 +1,5 @@
 import type { Role } from './role.js'
+import type { UserStatus } from './user-status.js'
 
 export interface User {
   id: string
@@ -6,14 +7,16 @@ export interface User {
   passwordHash: string | null
   emailHash: string | null
   roles: Role[]
+  status: UserStatus
   createdAt: Date
   updatedAt: Date
 }
 
 // These are for the repository layer - they work with hashed data
+// status is omitted: new users always default to UserStatus.Unverified
 export type CreateUserData = Omit<
   User,
-  'id' | 'roles' | 'createdAt' | 'updatedAt'
+  'id' | 'roles' | 'status' | 'createdAt' | 'updatedAt'
 >
 
 export type UpdateUserData = Partial<

--- a/libs/domain/src/errors/auth.ts
+++ b/libs/domain/src/errors/auth.ts
@@ -78,3 +78,12 @@ export class MissingRoleError extends AuthenticationError {
     this.name = 'MissingRoleError'
   }
 }
+
+export class AccessNotGrantedError extends AuthenticationError {
+  constructor() {
+    super(
+      "You're on the early-access waitlist. We're opening access in batches — please check back soon."
+    )
+    this.name = 'AccessNotGrantedError'
+  }
+}

--- a/libs/domain/src/errors/user.ts
+++ b/libs/domain/src/errors/user.ts
@@ -1,0 +1,13 @@
+export class UserError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'UserError'
+  }
+}
+
+export class UserNotFoundError extends UserError {
+  constructor(identifier?: string) {
+    super(identifier ? `User "${identifier}" not found` : 'User not found')
+    this.name = 'UserNotFoundError'
+  }
+}

--- a/libs/domain/src/index.ts
+++ b/libs/domain/src/index.ts
@@ -4,6 +4,7 @@
 // Entities
 export type { User, CreateUserData, UpdateUserData } from './entities/user.js'
 export { Role } from './entities/role.js'
+export { UserStatus } from './entities/user-status.js'
 export type { Pin, CreatePinData, UpdatePinData } from './entities/pin.js'
 export type {
   Tag,
@@ -54,7 +55,9 @@ export {
   TooManyResetRequestsError,
   EmailSendError,
   MissingRoleError,
+  AccessNotGrantedError,
 } from './errors/auth.js'
+export { UserError, UserNotFoundError } from './errors/user.js'
 export {
   PinError,
   PinNotFoundError,

--- a/libs/services/src/services/api-key.test.ts
+++ b/libs/services/src/services/api-key.test.ts
@@ -8,6 +8,7 @@ import {
   UnauthorizedApiKeyAccessError,
   ValidationError,
   Role,
+  UserStatus,
 } from '@pinsquirrel/domain'
 
 vi.mock('../utils/crypto.js', () => ({
@@ -27,6 +28,7 @@ describe('ApiKeyService', () => {
     passwordHash: 'hashedpassword',
     emailHash: null,
     roles: [Role.User],
+    status: UserStatus.Active,
     createdAt: new Date(),
     updatedAt: new Date(),
   }
@@ -37,6 +39,7 @@ describe('ApiKeyService', () => {
     passwordHash: 'hashedpassword',
     emailHash: null,
     roles: [Role.User],
+    status: UserStatus.Active,
     createdAt: new Date(),
     updatedAt: new Date(),
   }

--- a/libs/services/src/services/authentication.test.ts
+++ b/libs/services/src/services/authentication.test.ts
@@ -13,7 +13,10 @@ import {
   ResetTokenExpiredError,
   TooManyResetRequestsError,
   MissingRoleError,
+  AccessNotGrantedError,
+  UserNotFoundError,
   Role,
+  UserStatus,
 } from '@pinsquirrel/domain'
 
 // Mock the crypto module (which contains crypto functions)
@@ -44,6 +47,7 @@ describe('AuthenticationService', () => {
     passwordHash: 'hashedpassword',
     emailHash: null,
     roles: [Role.User],
+    status: UserStatus.Active,
     createdAt: new Date(),
     updatedAt: new Date(),
   }
@@ -437,6 +441,25 @@ describe('AuthenticationService', () => {
       )
     })
 
+    it('should throw AccessNotGrantedError when a waitlisted user signs in', async () => {
+      const waitlistedUser = {
+        ...mockUser,
+        status: UserStatus.Waitlist,
+        passwordHash: '$2b$10$validhash',
+      }
+      vi.mocked(mockUserRepository.findByUsername).mockResolvedValue(
+        waitlistedUser
+      )
+      vi.mocked(verifyPassword).mockResolvedValue(true)
+
+      await expect(
+        authService.login({
+          username: 'testuser',
+          password: 'password12345',
+        })
+      ).rejects.toThrow(AccessNotGrantedError)
+    })
+
     it('should throw validation error for invalid username', async () => {
       const loginInput = {
         username: 'ab', // too short
@@ -457,6 +480,42 @@ describe('AuthenticationService', () => {
       await expect(authService.login(loginInput)).rejects.toThrow(
         'Password must be at least 12 characters'
       )
+    })
+  })
+
+  describe('grantAccess', () => {
+    it('should move a waitlisted user to active', async () => {
+      const waitlistedUser = { ...mockUser, status: UserStatus.Waitlist }
+      const activatedUser = { ...mockUser, status: UserStatus.Active }
+      vi.mocked(mockUserRepository.findById).mockResolvedValue(waitlistedUser)
+      vi.mocked(mockUserRepository.update).mockResolvedValue(activatedUser)
+
+      const result = await authService.grantAccess(waitlistedUser.id)
+
+      expect(mockUserRepository.update).toHaveBeenCalledWith(
+        waitlistedUser.id,
+        { status: UserStatus.Active }
+      )
+      expect(result.status).toBe(UserStatus.Active)
+    })
+
+    it('should be idempotent for an already-active user', async () => {
+      const activeUser = { ...mockUser, status: UserStatus.Active }
+      vi.mocked(mockUserRepository.findById).mockResolvedValue(activeUser)
+
+      const result = await authService.grantAccess(activeUser.id)
+
+      expect(mockUserRepository.update).not.toHaveBeenCalled()
+      expect(result.status).toBe(UserStatus.Active)
+    })
+
+    it('should throw UserNotFoundError when the user does not exist', async () => {
+      vi.mocked(mockUserRepository.findById).mockResolvedValue(null)
+
+      await expect(authService.grantAccess('missing-id')).rejects.toThrow(
+        UserNotFoundError
+      )
+      expect(mockUserRepository.update).not.toHaveBeenCalled()
     })
   })
 
@@ -736,6 +795,34 @@ describe('AuthenticationService', () => {
       })
       expect(mockPasswordResetRepository.delete).toHaveBeenCalledWith(
         mockPasswordResetToken.id
+      )
+    })
+
+    it('should promote an unverified user to the waitlist when they set their password', async () => {
+      const unverifiedUser = { ...mockUser, status: UserStatus.Unverified }
+      vi.mocked(mockPasswordResetRepository.findByTokenHash).mockResolvedValue(
+        mockPasswordResetToken
+      )
+      vi.mocked(mockPasswordResetRepository.isValidToken).mockResolvedValue(
+        true
+      )
+      vi.mocked(mockUserRepository.findById).mockResolvedValue(unverifiedUser)
+      vi.mocked(mockUserRepository.update).mockResolvedValue(unverifiedUser)
+      vi.mocked(mockPasswordResetRepository.delete).mockResolvedValue(true)
+
+      await authService.resetPassword({
+        token: 'mock-token',
+        newPassword: 'newpassword123',
+      })
+
+      expect(mockUserRepository.update).toHaveBeenCalledWith(
+        unverifiedUser.id,
+        {
+          username: unverifiedUser.username,
+          passwordHash: 'hashed_newpassword123',
+          emailHash: unverifiedUser.emailHash,
+          status: UserStatus.Waitlist,
+        }
       )
     })
 

--- a/libs/services/src/services/authentication.ts
+++ b/libs/services/src/services/authentication.ts
@@ -3,8 +3,9 @@ import type {
   PasswordResetRepository,
   EmailService,
   User,
+  UpdateUserData,
 } from '@pinsquirrel/domain'
-import { Role } from '@pinsquirrel/domain'
+import { Role, UserStatus } from '@pinsquirrel/domain'
 import {
   InvalidCredentialsError,
   EmailVerificationRequiredError,
@@ -13,6 +14,8 @@ import {
   TooManyResetRequestsError,
   ValidationError,
   MissingRoleError,
+  AccessNotGrantedError,
+  UserNotFoundError,
 } from '@pinsquirrel/domain'
 import {
   hashPassword,
@@ -176,7 +179,38 @@ export class AuthenticationService {
       throw new MissingRoleError()
     }
 
+    // Only users who have been granted access can sign in. Verified accounts
+    // awaiting an access grant are still on the early-access waitlist.
+    if (user.status !== UserStatus.Active) {
+      throw new AccessNotGrantedError()
+    }
+
     return user
+  }
+
+  /**
+   * Grant a user access to the application, moving them off the early-access
+   * waitlist and into the active state. Idempotent: granting an already-active
+   * user is a no-op. Intended for manual/admin use.
+   */
+  async grantAccess(userId: string): Promise<User> {
+    const user = await this.userRepository.findById(userId)
+    if (!user) {
+      throw new UserNotFoundError(userId)
+    }
+
+    if (user.status === UserStatus.Active) {
+      return user
+    }
+
+    const updated = await this.userRepository.update(userId, {
+      status: UserStatus.Active,
+    })
+    if (!updated) {
+      throw new UserNotFoundError(userId)
+    }
+
+    return updated
   }
 
   async changePassword(input: {
@@ -384,11 +418,20 @@ export class AuthenticationService {
     const passwordHash = await hashPassword(input.newPassword)
 
     // Update the user's password
-    await this.userRepository.update(user.id, {
+    const updateData: UpdateUserData = {
       username: user.username,
       passwordHash,
       emailHash: user.emailHash,
-    })
+    }
+
+    // Setting a password completes email verification. For a brand-new
+    // account this is the moment they join the early-access waitlist.
+    // Never demote an already-active user resetting a forgotten password.
+    if (user.status === UserStatus.Unverified) {
+      updateData.status = UserStatus.Waitlist
+    }
+
+    await this.userRepository.update(user.id, updateData)
 
     // Delete the used token
     await this.passwordResetRepository.delete(resetToken.id)

--- a/libs/services/src/services/pin.test.ts
+++ b/libs/services/src/services/pin.test.ts
@@ -10,6 +10,7 @@ import {
   PinNotFoundError,
   UnauthorizedPinAccessError,
   DuplicatePinError,
+  UserStatus,
 } from '@pinsquirrel/domain'
 
 describe('PinService', () => {
@@ -43,6 +44,7 @@ describe('PinService', () => {
     passwordHash: 'hash',
     emailHash: 'emailhash',
     roles: [],
+    status: UserStatus.Active,
     createdAt: new Date('2024-01-01'),
     updatedAt: new Date('2024-01-01'),
   }

--- a/libs/services/src/services/tag.test.ts
+++ b/libs/services/src/services/tag.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { TagService } from './tag.js'
 import type { TagRepository, Tag, User } from '@pinsquirrel/domain'
-import { AccessControl, Role, TagNotFoundError } from '@pinsquirrel/domain'
+import {
+  AccessControl,
+  Role,
+  TagNotFoundError,
+  UserStatus,
+} from '@pinsquirrel/domain'
 
 describe('TagService.getUserTagById', () => {
   let service: TagService
@@ -13,6 +18,7 @@ describe('TagService.getUserTagById', () => {
     passwordHash: 'x',
     emailHash: null,
     roles: [Role.User],
+    status: UserStatus.Active,
     createdAt: new Date(),
     updatedAt: new Date(),
   }


### PR DESCRIPTION
## Summary

Reframes signup as an **early-access waitlist** and introduces a user lifecycle `status` to track where each account is in onboarding. `status` is an explicit, *exclusive* axis kept separate from the existing additive `Role` system (admin stays a role; lifecycle is a status).

```
 signup              set password (email link)     grant script (you)
  ──> unverified ──────────────────────────────> waitlist ──────────> active ──> can sign in
       pw: null      promote-only guard            pw: set    status flip   pw: set
```

- **unverified** — signed up, hasn't clicked the email link / set a password
- **waitlist** — verified (password set), awaiting an access grant
- **active** — granted; can sign in
- **admin** — orthogonal; `Role.Admin`, granted manually

## Changes

**domain** — `UserStatus` enum; `status` on `User` (omitted from `CreateUserData`, defaults to `unverified`); `AccessNotGrantedError`, `UserNotFoundError`.

**database** — `users.status` enum column (default `unverified`, not null); migration `0003` with **backfill** (existing users with a password → `active`; password-null → `unverified`); `update()` persists status.

**services** — `resetPassword` promotes `unverified → waitlist` when a password is first set (promote-only — never demotes an active user resetting a password); `login()` gates on `status === active`; new idempotent `grantAccess(userId)`.

**hono** — sign-in renders the waitlist message (403) for `AccessNotGrantedError`; signup copy reframed to early-access; `grant-access` CLI.

## How to grant access

```
pnpm --filter @pinsquirrel/hono grant-access <username>
```

## Design notes

- The login gate is the only access choke point — waitlist users can't obtain a session, so no per-route middleware is needed. `Role.User` is left untouched; `status` is the source of truth for the four states.
- **No grant-time email** (deferred by request): emails are stored hashed, so `grantAccess(userId)` can't recover an address. Signup copy and the waitlist message say "check back soon" instead of promising an email. If wanted later, the script can pass the plaintext email (already received via the `NOTIFY_EMAIL` signup notification) for `grantAccess` to verify + send.

## Testing

- Built TDD (RED→GREEN per slice). database 158 ✓, services 204 ✓.
- `pnpm quality` green (typecheck, lint, test, format, audit).
- Grant script smoke-tested end-to-end: grant → idempotent no-op → not-found (exit 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)