### PR TITLE
feat(auth): add grant-admin CLI script

### DIFF
--- a/apps/hono/package.json
+++ b/apps/hono/package.json
@@ -17,7 +17,8 @@
     "test:coverage": "vitest --run --coverage",
     "css:build": "tailwindcss -i ./src/styles/app.css -o ./src/static/styles.css",
     "css:watch": "tailwindcss -i ./src/styles/app.css -o ./src/static/styles.css --watch",
-    "grant-access": "tsx src/scripts/grant-access.ts"
+    "grant-access": "tsx src/scripts/grant-access.ts",
+    "grant-admin": "tsx src/scripts/grant-admin.ts"
   },
   "dependencies": {
     "@hono/mcp": "^0.2.5",

--- a/apps/hono/src/scripts/grant-admin.ts
+++ b/apps/hono/src/scripts/grant-admin.ts
@@ -1,0 +1,55 @@
+import 'dotenv/config'
+import {
+  createDatabaseClient,
+  DrizzleUserRepository,
+} from '@pinsquirrel/database'
+import { Role } from '@pinsquirrel/domain'
+
+/**
+ * Manually grant a user the Admin role.
+ *
+ * Usage:
+ *   pnpm --filter @pinsquirrel/hono grant-admin <username>
+ *
+ * Roles are additive: this adds Admin alongside the user's existing roles. The
+ * User role and active status (required to sign in) are left untouched.
+ * Idempotent: re-running on an existing admin reports no change.
+ */
+async function main(): Promise<void> {
+  const username = process.argv[2]
+  if (!username) {
+    console.error(
+      'Usage: pnpm --filter @pinsquirrel/hono grant-admin <username>'
+    )
+    process.exit(1)
+  }
+
+  const databaseUrl = process.env.DATABASE_URL
+  if (!databaseUrl) {
+    console.error('DATABASE_URL is not set')
+    process.exit(1)
+  }
+
+  const db = createDatabaseClient(databaseUrl)
+  const userRepository = new DrizzleUserRepository(db)
+
+  const user = await userRepository.findByUsername(username)
+  if (!user) {
+    console.error(`User "${username}" not found`)
+    process.exit(1)
+  }
+
+  if (user.roles.includes(Role.Admin)) {
+    console.log(`No change: "${user.username}" is already an admin.`)
+    process.exit(0)
+  }
+
+  await userRepository.addRole(user.id, Role.Admin)
+  console.log(`Granted the Admin role to "${user.username}".`)
+  process.exit(0)
+}
+
+main().catch((error: unknown) => {
+  console.error(error)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

Adds a `grant-admin` CLI as a companion to the `grant-access` script from #48, so making someone an admin no longer requires hand-written SQL.

```
pnpm --filter @pinsquirrel/hono grant-admin <username>
```

Roles are **additive** (the `user_roles` junction table), so this adds the `Admin` role *alongside* the user's existing roles via `userRepository.addRole`. The `User` role and `active` status — both required to sign in — are left untouched. Idempotent: re-running on an existing admin reports no change.

## Testing

- `pnpm quality` green (typecheck, lint, test, format, audit).
- Smoke-tested end-to-end against the dev DB: grants `Admin` (result `Admin,User` — `User` preserved) → idempotent no-op → not-found exits 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)