### PR TITLE
feat(admin): local web app to read and contact the waitlist

### DIFF
--- a/apps/admin/.gitignore
+++ b/apps/admin/.gitignore
@@ -1,0 +1,5 @@
+# Local admin configuration and private keys — never commit these.
+admin.config.json
+keys/
+*.key.json
+dist/

--- a/apps/admin/admin.config.example.json
+++ b/apps/admin/admin.config.example.json
@@ -1,0 +1,29 @@
+{
+  "sessionSecret": "change-me-to-a-long-random-string",
+  "environments": [
+    {
+      "name": "dev",
+      "label": "Development",
+      "databaseUrl": "mysql://pinsquirrel:pinsquirrel@localhost:3306/pinsquirrel",
+      "privateKeyPath": "./keys/dev-email-key.json",
+      "mailgun": {
+        "apiKey": "key-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "domain": "mg.example.com",
+        "fromEmail": "noreply@example.com",
+        "fromName": "PinSquirrel"
+      }
+    },
+    {
+      "name": "prod",
+      "label": "Production",
+      "databaseUrl": "mysql://user:pass@your-managed-host:3306/pinsquirrel",
+      "privateKeyPath": "./keys/prod-email-key.json",
+      "mailgun": {
+        "apiKey": "key-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "domain": "mg.example.com",
+        "fromEmail": "noreply@example.com",
+        "fromName": "PinSquirrel"
+      }
+    }
+  ]
+}

--- a/apps/admin/eslint.config.js
+++ b/apps/admin/eslint.config.js
@@ -1,0 +1,44 @@
+import eslint from '@eslint/js'
+import tseslint from 'typescript-eslint'
+import eslintPluginPrettier from 'eslint-plugin-prettier'
+import eslintConfigPrettier from 'eslint-config-prettier'
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  eslintConfigPrettier,
+  {
+    plugins: {
+      prettier: eslintPluginPrettier,
+    },
+    rules: {
+      'prettier/prettier': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_' },
+      ],
+    },
+    languageOptions: {
+      parserOptions: {
+        project: './tsconfig.json',
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+  {
+    files: ['**/*.js', '**/*.mjs'],
+    ...tseslint.configs.disableTypeChecked,
+  },
+  {
+    files: ['**/*.test.ts', '**/*.test.tsx', '**/*.spec.ts', '**/*.spec.tsx'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+    },
+  },
+  {
+    ignores: ['dist/**', 'node_modules/**', 'coverage/**'],
+  }
+)

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@pinsquirrel/admin",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "start": "tsx src/index.ts",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "test": "vitest --run",
+    "test:watch": "vitest --watch --coverage",
+    "test:coverage": "vitest --run --coverage"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.19.13",
+    "@pinsquirrel/crypto": "workspace:*",
+    "@pinsquirrel/database": "workspace:*",
+    "@pinsquirrel/domain": "workspace:*",
+    "@pinsquirrel/services": "workspace:*",
+    "dotenv": "^17.4.1",
+    "hono": "^4.12.25",
+    "mailgun.js": "^12.7.1"
+  },
+  "devDependencies": {
+    "@eslint/js": "^10",
+    "@types/node": "^24.12.2",
+    "@vitest/coverage-v8": "^4.1.2",
+    "eslint": "^10",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-prettier": "^5.5.5",
+    "prettier": "^3.8.1",
+    "tsx": "^4.21.0",
+    "typescript": "^6.0.2",
+    "typescript-eslint": "^8.58.0",
+    "vitest": "^4.1.2"
+  },
+  "engines": {
+    "node": ">=24.0.0"
+  }
+}

--- a/apps/admin/src/app.tsx
+++ b/apps/admin/src/app.tsx
@@ -1,0 +1,341 @@
+import { Hono } from 'hono'
+import { getSignedCookie, setSignedCookie, deleteCookie } from 'hono/cookie'
+import {
+  Role,
+  UserStatus,
+  InvalidCredentialsError,
+  AccessNotGrantedError,
+  MissingRoleError,
+  ValidationError,
+} from '@pinsquirrel/domain'
+import { openSealedEmail } from '@pinsquirrel/crypto'
+import { loadConfig, getEnvironment, type AdminEnvironment } from './config.js'
+import { getRuntime } from './runtime.js'
+import { readKeyFile, keyNeedsPassphrase, unlockPrivateKey } from './key.js'
+import {
+  createSession,
+  getSession,
+  updateSession,
+  destroySession,
+  type AdminSession,
+} from './session.js'
+import { sendBulk } from './mailer.js'
+import {
+  LoginPage,
+  UnlockPage,
+  WaitlistPage,
+  ComposePage,
+  SentPage,
+} from './views.js'
+import type { Context } from 'hono'
+
+const config = loadConfig()
+const COOKIE = 'admin_session'
+
+export const app = new Hono()
+
+// Safely read a text field from a parsed form body (values may be File).
+function field(body: Record<string, string | File>, name: string): string {
+  const value = body[name]
+  return typeof value === 'string' ? value : ''
+}
+
+// Friendly message for a transient DB/runtime failure after unlock; the
+// underlying error is logged to the local console for the operator.
+function dbErrorMessage(env: AdminEnvironment, error: unknown): string {
+  console.error(`[admin] database/runtime failure for "${env.name}":`, error)
+  return `Couldn't reach the ${env.label} database. Please try again.`
+}
+
+async function currentSession(
+  c: Context
+): Promise<{ id: string; session: AdminSession } | null> {
+  const id = await getSignedCookie(c, config.sessionSecret, COOKIE)
+  if (!id) return null
+  const session = getSession(id)
+  return session ? { id, session } : null
+}
+
+interface WaitlistRow {
+  username: string
+  email: string
+  joinedAt: string
+}
+
+async function loadWaitlist(
+  env: AdminEnvironment,
+  privateKey: string
+): Promise<WaitlistRow[]> {
+  const { userRepository } = getRuntime(env)
+  const users = await userRepository.findByStatus(UserStatus.Waitlist)
+  const rows: WaitlistRow[] = []
+  for (const user of users) {
+    let email = '(no sealed email)'
+    if (user.emailEncrypted) {
+      try {
+        email = await openSealedEmail(user.emailEncrypted, privateKey)
+      } catch {
+        email = '(decrypt failed)'
+      }
+    }
+    rows.push({
+      username: user.username,
+      email,
+      joinedAt: user.createdAt.toISOString().slice(0, 10),
+    })
+  }
+  return rows
+}
+
+app.get('/', async c => {
+  const sess = await currentSession(c)
+  if (!sess) return c.redirect('/login')
+  return c.redirect(sess.session.privateKey ? '/waitlist' : '/unlock')
+})
+
+app.get('/login', async c => {
+  if (await currentSession(c)) return c.redirect('/')
+  return c.html(<LoginPage environments={config.environments} />)
+})
+
+app.post('/login', async c => {
+  const body = await c.req.parseBody()
+  const environment = field(body, 'environment')
+  const username = field(body, 'username')
+  const password = field(body, 'password')
+
+  let env: AdminEnvironment
+  try {
+    env = getEnvironment(config, environment)
+  } catch {
+    return c.html(
+      <LoginPage
+        environments={config.environments}
+        username={username}
+        error="Unknown environment."
+      />,
+      400
+    )
+  }
+
+  try {
+    const user = await getRuntime(env).authService.login({ username, password })
+    if (!user.roles.includes(Role.Admin)) {
+      return c.html(
+        <LoginPage
+          environments={config.environments}
+          selected={environment}
+          username={username}
+          error="This account is not an admin."
+        />,
+        403
+      )
+    }
+    const id = createSession({
+      environment,
+      userId: user.id,
+      username: user.username,
+    })
+    await setSignedCookie(c, COOKIE, id, config.sessionSecret, {
+      httpOnly: true,
+      sameSite: 'Lax',
+      path: '/',
+    })
+    return c.redirect('/unlock')
+  } catch (error) {
+    const message =
+      error instanceof ValidationError ||
+      error instanceof InvalidCredentialsError
+        ? 'Invalid username or password.'
+        : error instanceof MissingRoleError ||
+            error instanceof AccessNotGrantedError
+          ? 'This account cannot sign in.'
+          : 'Could not connect to this environment.'
+    return c.html(
+      <LoginPage
+        environments={config.environments}
+        selected={environment}
+        username={username}
+        error={message}
+      />,
+      400
+    )
+  }
+})
+
+app.get('/unlock', async c => {
+  const sess = await currentSession(c)
+  if (!sess) return c.redirect('/login')
+  if (sess.session.privateKey) return c.redirect('/waitlist')
+
+  const env = getEnvironment(config, sess.session.environment)
+  try {
+    const contents = readKeyFile(env.privateKeyPath)
+    // Only prompt for a passphrase when the key file is actually encrypted.
+    if (keyNeedsPassphrase(contents)) {
+      return c.html(<UnlockPage envLabel={env.label} />)
+    }
+    // Raw (unencrypted) key — unlock now; only persist/redirect on success.
+    updateSession(sess.id, { privateKey: await unlockPrivateKey(contents) })
+    return c.redirect('/waitlist')
+  } catch {
+    return c.html(
+      <UnlockPage
+        envLabel={env.label}
+        error={`Could not read or unlock the key file at ${env.privateKeyPath}.`}
+      />,
+      500
+    )
+  }
+})
+
+app.post('/unlock', async c => {
+  const sess = await currentSession(c)
+  if (!sess) return c.redirect('/login')
+  const env = getEnvironment(config, sess.session.environment)
+  const body = await c.req.parseBody()
+  const passphrase = field(body, 'passphrase')
+
+  try {
+    const contents = readKeyFile(env.privateKeyPath)
+    const privateKey = await unlockPrivateKey(contents, passphrase)
+    updateSession(sess.id, { privateKey })
+    return c.redirect('/waitlist')
+  } catch {
+    return c.html(
+      <UnlockPage
+        envLabel={env.label}
+        error="Incorrect passphrase or unreadable key file."
+      />,
+      400
+    )
+  }
+})
+
+app.get('/waitlist', async c => {
+  const sess = await currentSession(c)
+  if (!sess) return c.redirect('/login')
+  if (!sess.session.privateKey) return c.redirect('/unlock')
+
+  const env = getEnvironment(config, sess.session.environment)
+  try {
+    const rows = await loadWaitlist(env, sess.session.privateKey)
+    return c.html(
+      <WaitlistPage
+        envLabel={env.label}
+        username={sess.session.username}
+        rows={rows}
+      />
+    )
+  } catch (error) {
+    return c.html(
+      <WaitlistPage
+        envLabel={env.label}
+        username={sess.session.username}
+        rows={[]}
+        error={dbErrorMessage(env, error)}
+      />,
+      500
+    )
+  }
+})
+
+app.get('/compose', async c => {
+  const sess = await currentSession(c)
+  if (!sess) return c.redirect('/login')
+  if (!sess.session.privateKey) return c.redirect('/unlock')
+
+  const env = getEnvironment(config, sess.session.environment)
+  try {
+    const rows = await loadWaitlist(env, sess.session.privateKey)
+    const recipientCount = rows.filter(r => r.email.includes('@')).length
+    return c.html(
+      <ComposePage envLabel={env.label} recipientCount={recipientCount} />
+    )
+  } catch (error) {
+    return c.html(
+      <ComposePage
+        envLabel={env.label}
+        recipientCount={0}
+        error={dbErrorMessage(env, error)}
+      />,
+      500
+    )
+  }
+})
+
+app.post('/send', async c => {
+  const sess = await currentSession(c)
+  if (!sess) return c.redirect('/login')
+  if (!sess.session.privateKey) return c.redirect('/unlock')
+
+  const env = getEnvironment(config, sess.session.environment)
+  const body = await c.req.parseBody()
+  const subject = field(body, 'subject').trim()
+  const messageBody = field(body, 'body').trim()
+
+  // Validate before any DB work so an empty submission returns 400 without
+  // querying the database or decrypting recipients.
+  if (!subject || !messageBody) {
+    return c.html(
+      <ComposePage
+        envLabel={env.label}
+        recipientCount={0}
+        subject={subject}
+        body={messageBody}
+        error="Subject and message are both required."
+      />,
+      400
+    )
+  }
+
+  // Recompute recipients from the live DB so we never trust a client-supplied
+  // list and never put plaintext emails on the wire until send time.
+  let recipients: string[]
+  try {
+    const rows = await loadWaitlist(env, sess.session.privateKey)
+    recipients = rows.map(r => r.email).filter(e => e.includes('@'))
+  } catch (error) {
+    return c.html(
+      <ComposePage
+        envLabel={env.label}
+        recipientCount={0}
+        subject={subject}
+        body={messageBody}
+        error={dbErrorMessage(env, error)}
+      />,
+      500
+    )
+  }
+
+  // Per-recipient send failures are captured inside sendBulk and shown on
+  // SentPage; this guard only covers an unexpected provider/client-setup throw.
+  try {
+    const results = await sendBulk(
+      env.mailgun,
+      recipients,
+      subject,
+      messageBody
+    )
+    return c.html(<SentPage envLabel={env.label} results={results} />)
+  } catch (error) {
+    console.error(`[admin] mail provider failure for "${env.name}":`, error)
+    return c.html(
+      <ComposePage
+        envLabel={env.label}
+        recipientCount={recipients.length}
+        subject={subject}
+        body={messageBody}
+        error="Couldn't reach the email provider. Please try again."
+      />,
+      500
+    )
+  }
+})
+
+app.post('/logout', async c => {
+  const sess = await currentSession(c)
+  if (sess) destroySession(sess.id)
+  deleteCookie(c, COOKIE, { path: '/' })
+  return c.redirect('/login')
+})

--- a/apps/admin/src/config.test.ts
+++ b/apps/admin/src/config.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { parseConfig, getEnvironment } from './config.js'
+
+const env = {
+  name: 'dev',
+  label: 'Development',
+  databaseUrl: 'mysql://localhost:3306/pinsquirrel',
+  privateKeyPath: './keys/dev.json',
+  mailgun: {
+    apiKey: 'key-x',
+    domain: 'mg.example.com',
+    fromEmail: 'noreply@example.com',
+    fromName: 'PinSquirrel',
+  },
+}
+const valid = JSON.stringify({ sessionSecret: 'a-secret', environments: [env] })
+
+describe('parseConfig', () => {
+  it('parses a valid config', () => {
+    const cfg = parseConfig(valid)
+    expect(cfg.sessionSecret).toBe('a-secret')
+    expect(cfg.environments).toHaveLength(1)
+    expect(cfg.environments[0].name).toBe('dev')
+    expect(cfg.environments[0].mailgun.domain).toBe('mg.example.com')
+  })
+
+  it('defaults the label to the name when omitted', () => {
+    const noLabel = JSON.stringify({
+      sessionSecret: 's',
+      environments: [{ ...env, label: undefined }],
+    })
+    expect(parseConfig(noLabel).environments[0].label).toBe('dev')
+  })
+
+  it('rejects non-JSON', () => {
+    expect(() => parseConfig('nope')).toThrow('Invalid admin config')
+  })
+
+  it('rejects a missing sessionSecret', () => {
+    const bad = JSON.stringify({ environments: [env] })
+    expect(() => parseConfig(bad)).toThrow('Invalid admin config')
+  })
+
+  it('rejects an empty environments array', () => {
+    const bad = JSON.stringify({ sessionSecret: 's', environments: [] })
+    expect(() => parseConfig(bad)).toThrow('Invalid admin config')
+  })
+
+  it('rejects an environment missing required fields', () => {
+    const bad = JSON.stringify({
+      sessionSecret: 's',
+      environments: [{ name: 'dev' }],
+    })
+    expect(() => parseConfig(bad)).toThrow('Invalid admin config')
+  })
+
+  it('rejects an environment with incomplete mailgun settings', () => {
+    const bad = JSON.stringify({
+      sessionSecret: 's',
+      environments: [{ ...env, mailgun: { apiKey: 'k' } }],
+    })
+    expect(() => parseConfig(bad)).toThrow('Invalid admin config')
+  })
+
+  it('rejects duplicate environment names', () => {
+    const dup = JSON.stringify({ sessionSecret: 's', environments: [env, env] })
+    expect(() => parseConfig(dup)).toThrow('Invalid admin config')
+  })
+})
+
+describe('getEnvironment', () => {
+  it('returns the named environment', () => {
+    const cfg = parseConfig(valid)
+    expect(getEnvironment(cfg, 'dev').label).toBe('Development')
+  })
+
+  it('throws for an unknown environment', () => {
+    const cfg = parseConfig(valid)
+    expect(() => getEnvironment(cfg, 'nope')).toThrow()
+  })
+})

--- a/apps/admin/src/config.ts
+++ b/apps/admin/src/config.ts
@@ -1,0 +1,126 @@
+import { readFileSync } from 'node:fs'
+
+export interface MailgunSettings {
+  apiKey: string
+  domain: string
+  fromEmail: string
+  fromName?: string
+}
+
+export interface AdminEnvironment {
+  name: string
+  label: string
+  databaseUrl: string
+  privateKeyPath: string
+  mailgun: MailgunSettings
+}
+
+export interface AdminConfig {
+  sessionSecret: string
+  environments: AdminEnvironment[]
+}
+
+function invalid(detail: string): never {
+  throw new Error(`Invalid admin config: ${detail}`)
+}
+
+function requireString(
+  obj: Record<string, unknown>,
+  field: string,
+  context: string
+): string {
+  const value = obj[field]
+  if (typeof value !== 'string' || value.length === 0) {
+    invalid(`${context} is missing or has an invalid "${field}"`)
+  }
+  return value
+}
+
+function asRecord(value: unknown, context: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    invalid(`${context} must be an object`)
+  }
+  return value as Record<string, unknown>
+}
+
+function parseMailgun(value: unknown, context: string): MailgunSettings {
+  const obj = asRecord(value, `${context} mailgun`)
+  const fromName = obj.fromName
+  if (fromName !== undefined && typeof fromName !== 'string') {
+    invalid(`${context} mailgun has an invalid "fromName"`)
+  }
+  return {
+    apiKey: requireString(obj, 'apiKey', `${context} mailgun`),
+    domain: requireString(obj, 'domain', `${context} mailgun`),
+    fromEmail: requireString(obj, 'fromEmail', `${context} mailgun`),
+    fromName,
+  }
+}
+
+function parseEnvironment(value: unknown, index: number): AdminEnvironment {
+  const context = `environment[${index}]`
+  const obj = asRecord(value, context)
+  const name = requireString(obj, 'name', context)
+  const label =
+    typeof obj.label === 'string' && obj.label.length > 0 ? obj.label : name
+  return {
+    name,
+    label,
+    databaseUrl: requireString(obj, 'databaseUrl', context),
+    privateKeyPath: requireString(obj, 'privateKeyPath', context),
+    mailgun: parseMailgun(obj.mailgun, context),
+  }
+}
+
+export function parseConfig(contents: string): AdminConfig {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(contents)
+  } catch {
+    invalid('not valid JSON')
+  }
+  const obj = asRecord(parsed, 'config')
+  const sessionSecret = requireString(obj, 'sessionSecret', 'config')
+
+  if (!Array.isArray(obj.environments) || obj.environments.length === 0) {
+    invalid('"environments" must be a non-empty array')
+  }
+  const environments = obj.environments.map((e, i) => parseEnvironment(e, i))
+
+  const names = new Set<string>()
+  for (const e of environments) {
+    if (names.has(e.name)) {
+      invalid(`duplicate environment name "${e.name}"`)
+    }
+    names.add(e.name)
+  }
+
+  return { sessionSecret, environments }
+}
+
+export function getEnvironment(
+  config: AdminConfig,
+  name: string
+): AdminEnvironment {
+  const env = config.environments.find(e => e.name === name)
+  if (!env) {
+    throw new Error(`Unknown environment "${name}"`)
+  }
+  return env
+}
+
+/** Read and parse the admin config file (default ./admin.config.json). */
+export function loadConfig(
+  path: string = process.env.ADMIN_CONFIG ?? './admin.config.json'
+): AdminConfig {
+  let contents: string
+  try {
+    contents = readFileSync(path, 'utf8')
+  } catch (error) {
+    throw new Error(
+      `Could not read admin config at ${path}. Copy admin.config.example.json to admin.config.json.`,
+      { cause: error }
+    )
+  }
+  return parseConfig(contents)
+}

--- a/apps/admin/src/index.ts
+++ b/apps/admin/src/index.ts
@@ -1,0 +1,9 @@
+import 'dotenv/config'
+import { serve } from '@hono/node-server'
+import { app } from './app.js'
+
+const port = Number(process.env.PORT) || 8200
+
+serve({ fetch: app.fetch, port })
+
+console.log(`PinSquirrel Admin running at http://localhost:${port}`)

--- a/apps/admin/src/key.test.ts
+++ b/apps/admin/src/key.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  generateKeyPair,
+  serializeRawPrivateKey,
+  wrapPrivateKey,
+} from '@pinsquirrel/crypto'
+import { readKeyFile, keyNeedsPassphrase, unlockPrivateKey } from './key.js'
+
+describe('admin key handling', () => {
+  it('reads and unlocks a raw key without a passphrase', async () => {
+    const { privateKey } = await generateKeyPair()
+    const path = join(tmpdir(), `admin-raw-${process.pid}.json`)
+    writeFileSync(path, serializeRawPrivateKey(privateKey))
+    try {
+      const contents = readKeyFile(path)
+      expect(keyNeedsPassphrase(contents)).toBe(false)
+      expect(await unlockPrivateKey(contents)).toBe(privateKey)
+    } finally {
+      rmSync(path, { force: true })
+    }
+  })
+
+  it('detects an encrypted key and unlocks it with the passphrase', async () => {
+    const { privateKey } = await generateKeyPair()
+    const path = join(tmpdir(), `admin-enc-${process.pid}.json`)
+    writeFileSync(path, await wrapPrivateKey(privateKey, 'pw'))
+    try {
+      const contents = readKeyFile(path)
+      expect(keyNeedsPassphrase(contents)).toBe(true)
+      expect(await unlockPrivateKey(contents, 'pw')).toBe(privateKey)
+    } finally {
+      rmSync(path, { force: true })
+    }
+  })
+
+  it('rejects an encrypted key with a wrong or missing passphrase', async () => {
+    const { privateKey } = await generateKeyPair()
+    const path = join(tmpdir(), `admin-enc-neg-${process.pid}.json`)
+    writeFileSync(path, await wrapPrivateKey(privateKey, 'correct-pass'))
+    try {
+      const contents = readKeyFile(path)
+      expect(keyNeedsPassphrase(contents)).toBe(true)
+      await expect(unlockPrivateKey(contents, 'wrong-pass')).rejects.toThrow()
+      await expect(unlockPrivateKey(contents)).rejects.toThrow()
+    } finally {
+      rmSync(path, { force: true })
+    }
+  })
+
+  it('throws a clear error when the key file is missing', () => {
+    expect(() =>
+      readKeyFile(join(tmpdir(), 'admin-nope-does-not-exist.json'))
+    ).toThrow('Could not read private key')
+  })
+})

--- a/apps/admin/src/key.ts
+++ b/apps/admin/src/key.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs'
+import { isEncryptedPrivateKey, loadPrivateKey } from '@pinsquirrel/crypto'
+
+/** Read a private key file from disk, with a clear error if it's missing. */
+export function readKeyFile(path: string): string {
+  try {
+    return readFileSync(path, 'utf8')
+  } catch (error) {
+    throw new Error(`Could not read private key at ${path}`, { cause: error })
+  }
+}
+
+/** Whether the key file is passphrase-encrypted (so the UI must prompt). */
+export function keyNeedsPassphrase(contents: string): boolean {
+  return isEncryptedPrivateKey(contents)
+}
+
+/** Decrypt/return the base64 private key. Throws on a wrong/missing passphrase. */
+export function unlockPrivateKey(
+  contents: string,
+  passphrase?: string
+): Promise<string> {
+  return loadPrivateKey(contents, passphrase)
+}

--- a/apps/admin/src/mailer.test.ts
+++ b/apps/admin/src/mailer.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { isTransient, sendBulk } from './mailer.js'
+
+// Mock the Mailgun client so no network calls happen and we can observe
+// messages.create. vi.hoisted lets the mock factory reference createMock.
+const { createMock } = vi.hoisted(() => ({ createMock: vi.fn() }))
+
+vi.mock('mailgun.js', () => ({
+  default: class MockMailgun {
+    client() {
+      return { messages: { create: createMock } }
+    }
+  },
+}))
+
+const settings = {
+  apiKey: 'key-test',
+  domain: 'mg.test',
+  fromEmail: 'no-reply@test',
+  fromName: 'Test',
+}
+
+describe('isTransient', () => {
+  it('retries on rate limiting and server errors', () => {
+    expect(isTransient({ status: 429 })).toBe(true)
+    expect(isTransient({ status: 500 })).toBe(true)
+    expect(isTransient({ status: 503 })).toBe(true)
+  })
+
+  it('retries on network/timeout errors that carry no status', () => {
+    expect(isTransient(new Error('socket hang up'))).toBe(true)
+  })
+
+  it('treats null/undefined thrown values as transient without throwing', () => {
+    expect(isTransient(null)).toBe(true)
+    expect(isTransient(undefined)).toBe(true)
+  })
+
+  it('does not retry on client errors', () => {
+    expect(isTransient({ status: 400 })).toBe(false)
+    expect(isTransient({ status: 401 })).toBe(false)
+    expect(isTransient({ status: 404 })).toBe(false)
+  })
+})
+
+describe('sendBulk', () => {
+  beforeEach(() => {
+    createMock.mockReset()
+  })
+
+  it('sends one isolated message per recipient', async () => {
+    createMock.mockResolvedValue({ id: 'ok' })
+
+    const results = await sendBulk(
+      settings,
+      ['a@example.com', 'b@example.com'],
+      'Hello',
+      'Body text'
+    )
+
+    expect(createMock).toHaveBeenCalledTimes(2)
+    expect(createMock).toHaveBeenNthCalledWith(1, 'mg.test', {
+      from: 'Test <no-reply@test>',
+      to: ['a@example.com'],
+      subject: 'Hello',
+      text: 'Body text',
+    })
+    expect(createMock).toHaveBeenNthCalledWith(2, 'mg.test', {
+      from: 'Test <no-reply@test>',
+      to: ['b@example.com'],
+      subject: 'Hello',
+      text: 'Body text',
+    })
+    expect(results).toEqual([
+      { recipient: 'a@example.com', ok: true },
+      { recipient: 'b@example.com', ok: true },
+    ])
+  })
+
+  it('continues after a failure and returns per-recipient results', async () => {
+    // First recipient fails permanently (4xx, no retry); second succeeds.
+    createMock
+      .mockRejectedValueOnce(
+        Object.assign(new Error('bad request'), { status: 400 })
+      )
+      .mockResolvedValueOnce({ id: 'ok' })
+
+    const results = await sendBulk(
+      settings,
+      ['bad@example.com', 'good@example.com'],
+      'S',
+      'B'
+    )
+
+    expect(createMock).toHaveBeenCalledTimes(2)
+    expect(results).toEqual([
+      { recipient: 'bad@example.com', ok: false, error: 'bad request' },
+      { recipient: 'good@example.com', ok: true },
+    ])
+  })
+})

--- a/apps/admin/src/mailer.ts
+++ b/apps/admin/src/mailer.ts
@@ -1,0 +1,88 @@
+import Mailgun from 'mailgun.js'
+import type { MailgunSettings } from './config.js'
+
+export interface SendResult {
+  recipient: string
+  ok: boolean
+  error?: string
+}
+
+// Abort a stuck request rather than relying on Mailgun's default (0 = none).
+const REQUEST_TIMEOUT_MS = 30_000
+const MAX_ATTEMPTS = 3
+const RETRY_BASE_MS = 500
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+/**
+ * Retry only on likely-transient failures: network/timeout errors (no status),
+ * rate limiting (429), or server errors (5xx). Client errors (4xx) fail fast.
+ */
+export function isTransient(error: unknown): boolean {
+  const status =
+    typeof error === 'object' && error !== null && 'status' in error
+      ? (error as { status?: unknown }).status
+      : undefined
+  if (status === undefined) return true // no status => network/timeout
+  if (status === 429) return true
+  return typeof status === 'number' && status >= 500
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+async function withRetry(send: () => Promise<unknown>): Promise<void> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      await send()
+      return
+    } catch (error) {
+      if (attempt >= MAX_ATTEMPTS || !isTransient(error)) throw error
+      await sleep(RETRY_BASE_MS * 2 ** (attempt - 1))
+    }
+  }
+}
+
+/**
+ * Send a plain-text message to each recipient individually (one Mailgun message
+ * per address, so recipients never see each other and one failure doesn't block
+ * the rest). Transient failures are retried with backoff. Returns a
+ * per-recipient result.
+ */
+export async function sendBulk(
+  settings: MailgunSettings,
+  recipients: string[],
+  subject: string,
+  body: string
+): Promise<SendResult[]> {
+  const mailgun = new Mailgun(FormData)
+  const client = mailgun.client({
+    username: 'api',
+    key: settings.apiKey,
+    timeout: REQUEST_TIMEOUT_MS,
+  })
+  const from = settings.fromName
+    ? `${settings.fromName} <${settings.fromEmail}>`
+    : settings.fromEmail
+
+  const results: SendResult[] = []
+  for (const recipient of recipients) {
+    try {
+      await withRetry(() =>
+        client.messages.create(settings.domain, {
+          from,
+          to: [recipient],
+          subject,
+          text: body,
+        })
+      )
+      results.push({ recipient, ok: true })
+    } catch (error) {
+      results.push({ recipient, ok: false, error: errorMessage(error) })
+    }
+  }
+  return results
+}

--- a/apps/admin/src/runtime.ts
+++ b/apps/admin/src/runtime.ts
@@ -1,0 +1,28 @@
+import {
+  createDatabaseClient,
+  DrizzleUserRepository,
+} from '@pinsquirrel/database'
+import { AuthenticationService } from '@pinsquirrel/services'
+import type { AdminEnvironment } from './config.js'
+
+export interface EnvRuntime {
+  userRepository: DrizzleUserRepository
+  authService: AuthenticationService
+}
+
+// One DB client/repository set per environment, created lazily and reused.
+const cache = new Map<string, EnvRuntime>()
+
+export function getRuntime(env: AdminEnvironment): EnvRuntime {
+  let runtime = cache.get(env.name)
+  if (!runtime) {
+    const db = createDatabaseClient(env.databaseUrl)
+    const userRepository = new DrizzleUserRepository(db)
+    runtime = {
+      userRepository,
+      authService: new AuthenticationService(userRepository),
+    }
+    cache.set(env.name, runtime)
+  }
+  return runtime
+}

--- a/apps/admin/src/session.ts
+++ b/apps/admin/src/session.ts
@@ -1,0 +1,33 @@
+import { randomBytes } from 'node:crypto'
+
+export interface AdminSession {
+  environment: string
+  userId: string
+  username: string
+  // The unlocked base64 private key. Held only in this process's memory, never
+  // written to a cookie or any database. Undefined until the key is unlocked.
+  privateKey?: string
+}
+
+// In-memory only: sessions (and the unlocked key) clear on restart, and are
+// never persisted to the target databases.
+const sessions = new Map<string, AdminSession>()
+
+export function createSession(data: AdminSession): string {
+  const id = randomBytes(32).toString('base64url')
+  sessions.set(id, data)
+  return id
+}
+
+export function getSession(id: string | undefined): AdminSession | undefined {
+  return id ? sessions.get(id) : undefined
+}
+
+export function updateSession(id: string, patch: Partial<AdminSession>): void {
+  const existing = sessions.get(id)
+  if (existing) sessions.set(id, { ...existing, ...patch })
+}
+
+export function destroySession(id: string | undefined): void {
+  if (id) sessions.delete(id)
+}

--- a/apps/admin/src/views.tsx
+++ b/apps/admin/src/views.tsx
@@ -1,0 +1,228 @@
+import type { FC, PropsWithChildren } from 'hono/jsx'
+import { html, raw } from 'hono/html'
+import type { SendResult } from './mailer.js'
+
+const styles = `
+  :root { color-scheme: light dark; }
+  * { box-sizing: border-box; }
+  body { font-family: system-ui, sans-serif; margin: 0; background: #0f172a; color: #e2e8f0; }
+  .wrap { max-width: 820px; margin: 0 auto; padding: 2rem 1.25rem; }
+  h1 { font-size: 1.35rem; margin: 0 0 0.25rem; }
+  .muted { color: #94a3b8; font-size: 0.9rem; }
+  .card { background: #1e293b; border: 1px solid #334155; border-radius: 10px; padding: 1.25rem; margin-top: 1rem; }
+  label { display: block; font-size: 0.85rem; margin: 0.75rem 0 0.25rem; color: #cbd5e1; }
+  input, select, textarea { width: 100%; padding: 0.55rem 0.65rem; border-radius: 8px; border: 1px solid #475569; background: #0f172a; color: #e2e8f0; font: inherit; }
+  textarea { min-height: 200px; resize: vertical; }
+  button, .btn { display: inline-block; margin-top: 1rem; padding: 0.55rem 1rem; border-radius: 8px; border: 0; background: #6366f1; color: #fff; font: inherit; font-weight: 600; cursor: pointer; text-decoration: none; }
+  .btn-secondary { background: #334155; }
+  .row { display: flex; gap: 1rem; align-items: center; justify-content: space-between; }
+  table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; font-size: 0.9rem; }
+  th, td { text-align: left; padding: 0.5rem 0.6rem; border-bottom: 1px solid #334155; }
+  th { color: #94a3b8; font-weight: 600; }
+  .error { background: #7f1d1d; color: #fecaca; padding: 0.6rem 0.8rem; border-radius: 8px; margin-top: 0.75rem; font-size: 0.9rem; }
+  .ok { color: #86efac; } .bad { color: #fca5a5; }
+  code { background: #0f172a; padding: 0.1rem 0.35rem; border-radius: 4px; }
+`
+
+const Layout: FC<PropsWithChildren<{ title: string }>> = ({
+  title,
+  children,
+}) =>
+  html`<!doctype html>
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>${title} · PinSquirrel Admin</title>
+        <style>
+          ${raw(styles)}
+        </style>
+      </head>
+      <body>
+        <div class="wrap">${children}</div>
+      </body>
+    </html>`
+
+export const LoginPage: FC<{
+  environments: { name: string; label: string }[]
+  error?: string
+  selected?: string
+  username?: string
+}> = ({ environments, error, selected, username }) => (
+  <Layout title="Sign in">
+    <h1>PinSquirrel Admin</h1>
+    <p class="muted">
+      Sign in with an admin account for the chosen environment.
+    </p>
+    <div class="card">
+      {error ? <div class="error">{error}</div> : ''}
+      <form method="post" action="/login">
+        <label for="environment">Environment</label>
+        <select id="environment" name="environment">
+          {environments.map(e => (
+            <option value={e.name} selected={e.name === selected}>
+              {e.label}
+            </option>
+          ))}
+        </select>
+        <label for="username">Username</label>
+        <input id="username" name="username" value={username ?? ''} required />
+        <label for="password">Password</label>
+        <input id="password" name="password" type="password" required />
+        <button type="submit">Sign in</button>
+      </form>
+    </div>
+  </Layout>
+)
+
+export const UnlockPage: FC<{ envLabel: string; error?: string }> = ({
+  envLabel,
+  error,
+}) => (
+  <Layout title="Unlock key">
+    <h1>Unlock decryption key</h1>
+    <p class="muted">{envLabel} — this key file is encrypted.</p>
+    <div class="card">
+      {error ? <div class="error">{error}</div> : ''}
+      <form method="post" action="/unlock">
+        <label for="passphrase">Passphrase</label>
+        <input id="passphrase" name="passphrase" type="password" required />
+        <button type="submit">Unlock</button>
+      </form>
+    </div>
+  </Layout>
+)
+
+export const WaitlistPage: FC<{
+  envLabel: string
+  username: string
+  rows: { username: string; email: string; joinedAt: string }[]
+  error?: string
+}> = ({ envLabel, username, rows, error }) => (
+  <Layout title="Waitlist">
+    <div class="row">
+      <div>
+        <h1>Waitlist · {rows.length}</h1>
+        <p class="muted">
+          {envLabel} — signed in as {username}
+        </p>
+      </div>
+      <form method="post" action="/logout">
+        <button class="btn-secondary" type="submit">
+          Sign out
+        </button>
+      </form>
+    </div>
+    <div class="card">
+      {error ? <div class="error">{error}</div> : ''}
+      {rows.length === 0 ? (
+        error ? (
+          ''
+        ) : (
+          <p class="muted">No one is on the waitlist.</p>
+        )
+      ) : (
+        <table>
+          <thead>
+            <tr>
+              <th>Username</th>
+              <th>Email</th>
+              <th>Joined</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(r => (
+              <tr>
+                <td>{r.username}</td>
+                <td>{r.email}</td>
+                <td class="muted">{r.joinedAt}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      {rows.length > 0 ? (
+        <a class="btn" href="/compose">
+          Compose message
+        </a>
+      ) : (
+        ''
+      )}
+    </div>
+  </Layout>
+)
+
+export const ComposePage: FC<{
+  envLabel: string
+  recipientCount: number
+  error?: string
+  subject?: string
+  body?: string
+}> = ({ envLabel, recipientCount, error, subject, body }) => (
+  <Layout title="Compose">
+    <div class="row">
+      <div>
+        <h1>Compose message</h1>
+        <p class="muted">
+          {envLabel} — sends individually to {recipientCount} waitlisted{' '}
+          {recipientCount === 1 ? 'person' : 'people'}.
+        </p>
+      </div>
+      <a class="btn btn-secondary" href="/waitlist">
+        Back
+      </a>
+    </div>
+    <div class="card">
+      {error ? <div class="error">{error}</div> : ''}
+      <form method="post" action="/send">
+        <label for="subject">Subject</label>
+        <input id="subject" name="subject" value={subject ?? ''} required />
+        <label for="body">Message (plain text)</label>
+        <textarea id="body" name="body" required>
+          {body ?? ''}
+        </textarea>
+        <button type="submit">Send to {recipientCount}</button>
+      </form>
+    </div>
+  </Layout>
+)
+
+export const SentPage: FC<{ envLabel: string; results: SendResult[] }> = ({
+  envLabel,
+  results,
+}) => {
+  const sent = results.filter(r => r.ok).length
+  const failed = results.length - sent
+  return (
+    <Layout title="Sent">
+      <h1>Sent</h1>
+      <p class="muted">
+        {envLabel} — <span class="ok">{sent} delivered</span>
+        {failed > 0 ? <span class="bad">{`, ${failed} failed`}</span> : ''}
+      </p>
+      <div class="card">
+        <table>
+          <thead>
+            <tr>
+              <th>Recipient</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {results.map(r => (
+              <tr>
+                <td>{r.recipient}</td>
+                <td class={r.ok ? 'ok' : 'bad'}>
+                  {r.ok ? 'sent' : (r.error ?? 'failed')}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <a class="btn btn-secondary" href="/waitlist">
+          Back to waitlist
+        </a>
+      </div>
+    </Layout>
+  )
+}

--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "types": ["node", "vitest/globals"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "hono/jsx"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/admin/vitest.config.ts
+++ b/apps/admin/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      exclude: ['node_modules/', 'dist/', '**/*.test.ts'],
+    },
+  },
+})

--- a/libs/database/src/repositories/user.test.ts
+++ b/libs/database/src/repositories/user.test.ts
@@ -170,6 +170,36 @@ describe('DrizzleUserRepository - Integration Tests', () => {
     })
   })
 
+  describe('findByStatus', () => {
+    it('returns only users with the given status', async () => {
+      const waitlisted = await repository.create({
+        username: `wl-${crypto.randomUUID().slice(0, 8)}`,
+        passwordHash: 'h',
+        emailHash: null,
+        emailEncrypted: 'sealed-blob',
+      })
+      await repository.update(waitlisted.id, { status: UserStatus.Waitlist })
+
+      const active = await repository.create({
+        username: `act-${crypto.randomUUID().slice(0, 8)}`,
+        passwordHash: 'h',
+        emailHash: null,
+      })
+      await repository.update(active.id, { status: UserStatus.Active })
+
+      const result = await repository.findByStatus(UserStatus.Waitlist)
+
+      const ids = result.map(u => u.id)
+      expect(ids).toContain(waitlisted.id)
+      expect(ids).not.toContain(active.id)
+      expect(result.every(u => u.status === UserStatus.Waitlist)).toBe(true)
+      // Email ciphertext is carried through so the admin app can decrypt it
+      expect(result.find(u => u.id === waitlisted.id)?.emailEncrypted).toBe(
+        'sealed-blob'
+      )
+    })
+  })
+
   describe('list', () => {
     it('should return users with limit', async () => {
       await Promise.all([

--- a/libs/database/src/repositories/user.ts
+++ b/libs/database/src/repositories/user.ts
@@ -4,6 +4,7 @@ import type {
   User,
   UserRepository,
   Role,
+  UserStatus,
 } from '@pinsquirrel/domain'
 import { eq, and, sql } from 'drizzle-orm'
 import type { MySql2Database } from 'drizzle-orm/mysql2'
@@ -56,6 +57,17 @@ export class DrizzleUserRepository implements UserRepository {
 
     if (!result[0]) return null
     return await this.attachRoles(result[0] as User)
+  }
+
+  async findByStatus(status: UserStatus): Promise<User[]> {
+    const results = await this.db
+      .select()
+      .from(users)
+      .where(eq(users.status, status))
+
+    return await Promise.all(
+      results.map(user => this.attachRoles(user as User))
+    )
   }
 
   async findAll(): Promise<User[]> {

--- a/libs/domain/src/interfaces/user-repository.ts
+++ b/libs/domain/src/interfaces/user-repository.ts
@@ -1,5 +1,6 @@
 import type { User, CreateUserData, UpdateUserData } from '../entities/user.js'
 import type { Role } from '../entities/role.js'
+import type { UserStatus } from '../entities/user-status.js'
 import type { Repository } from './repository.js'
 
 export interface UserRepository extends Repository<
@@ -9,5 +10,6 @@ export interface UserRepository extends Repository<
 > {
   findByEmailHash(emailHash: string): Promise<User | null>
   findByUsername(username: string): Promise<User | null>
+  findByStatus(status: UserStatus): Promise<User[]>
   addRole(userId: string, role: Role): Promise<void>
 }

--- a/libs/services/src/services/authentication.test.ts
+++ b/libs/services/src/services/authentication.test.ts
@@ -66,6 +66,7 @@ describe('AuthenticationService', () => {
       findById: vi.fn(),
       findByEmailHash: vi.fn(),
       findByUsername: vi.fn(),
+      findByStatus: vi.fn(),
       findAll: vi.fn(),
       create: vi.fn(),
       update: vi.fn(),

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "turbo build",
     "dev": "pnpm --filter @pinsquirrel/hono dev",
+    "admin": "pnpm --filter @pinsquirrel/admin dev",
     "start": "pnpm --filter @pinsquirrel/hono start",
     "typecheck": "turbo typecheck",
     "lint": "turbo lint",
@@ -48,6 +49,7 @@
   },
   "lint-staged": {
     "apps/hono/src/**/*.{ts,tsx}": "pnpm --filter @pinsquirrel/hono eslint --fix",
+    "apps/admin/src/**/*.{ts,tsx}": "pnpm --filter @pinsquirrel/admin eslint --fix",
     "libs/services/**/*.{ts,tsx,js,jsx}": "pnpm --filter @pinsquirrel/services eslint --fix",
     "libs/database/**/*.{ts,tsx,js,jsx}": "pnpm --filter @pinsquirrel/database eslint --fix",
     "libs/domain/**/*.{ts,tsx,js,jsx}": "pnpm --filter @pinsquirrel/domain eslint --fix",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,67 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2(@types/node@24.12.2)(happy-dom@18.0.1)(vite@6.3.6(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
 
+  apps/admin:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.13
+        version: 1.19.13(hono@4.12.26)
+      '@pinsquirrel/crypto':
+        specifier: workspace:*
+        version: link:../../libs/crypto
+      '@pinsquirrel/database':
+        specifier: workspace:*
+        version: link:../../libs/database
+      '@pinsquirrel/domain':
+        specifier: workspace:*
+        version: link:../../libs/domain
+      '@pinsquirrel/services':
+        specifier: workspace:*
+        version: link:../../libs/services
+      dotenv:
+        specifier: ^17.4.1
+        version: 17.4.1
+      hono:
+        specifier: ^4.12.25
+        version: 4.12.26
+      mailgun.js:
+        specifier: ^12.7.1
+        version: 12.7.1
+    devDependencies:
+      '@eslint/js':
+        specifier: ^10
+        version: 10.0.1(eslint@10.2.0(jiti@2.6.1))
+      '@types/node':
+        specifier: ^24.12.2
+        version: 24.12.2
+      '@vitest/coverage-v8':
+        specifier: ^4.1.2
+        version: 4.1.2(vitest@4.1.2(@types/node@24.12.2)(happy-dom@18.0.1)(vite@6.3.6(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)))
+      eslint:
+        specifier: ^10
+        version: 10.2.0(jiti@2.6.1)
+      eslint-config-prettier:
+        specifier: ^10.1.8
+        version: 10.1.8(eslint@10.2.0(jiti@2.6.1))
+      eslint-plugin-prettier:
+        specifier: ^5.5.5
+        version: 5.5.5(eslint-config-prettier@10.1.8(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1))(prettier@3.8.1)
+      prettier:
+        specifier: ^3.8.1
+        version: 3.8.1
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+      typescript-eslint:
+        specifier: ^8.58.0
+        version: 8.58.0(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@types/node@24.12.2)(happy-dom@18.0.1)(vite@6.3.6(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+
   apps/hono:
     dependencies:
       '@hono/mcp':


### PR DESCRIPTION
## Summary

Adds **`apps/admin`** — the offline counterpart to the server-side email sealing (#50). The public app server seals waitlist emails to a public key and *can't* read them; this local tool holds the private key, decrypts them locally, and lets you email the waitlist.

Run it with **`pnpm admin`** (defaults to `http://localhost:8200`).

### Flow
pick environment → sign in (Admin role, against that env's DB) → unlock the decryption key (passphrase **only if** the key file is encrypted) → view the waitlist with decrypted emails → compose → send via Mailgun.

## Design

- **Multi-environment** via a **gitignored `admin.config.json`** (dev / prod / future staging), each with its own `databaseUrl`, `privateKeyPath`, and Mailgun creds. `admin.config.example.json` is committed; the config is validated on load with deterministic errors.
- **Own session, never touches target DBs:** an in-memory store keyed by a signed cookie. The unlocked private key lives **only in this process's memory** — never in a cookie, never written to any database.
- **Decryption is local:** uses `@pinsquirrel/crypto` `openSealedEmail` with the private key loaded from the configured path. Because the admin app runs your code (not code served by the public server), there's no served-code trust gap.
- **Send safety:** recipients are recomputed from the **live DB** at send time (never trusted from the client), and each message is sent individually so addresses stay private and one failure doesn't block the rest.
- New **`UserRepository.findByStatus(status)`** to list waitlisted users.
- Deployable standalone (its own `.env`/config) at e.g. `admin.example.com` on separate infra, if ever wanted.

## Testing

- **TDD** for the logic: config parser (valid/invalid/duplicate/defaults), key handling (read, "prompt only when encrypted", unlock with/without passphrase, missing file), and `findByStatus` (DB integration). 
- App shell **smoke-tested end-to-end**: boots, serves `/login`, and the bad-credentials path exercises the real per-env DB → `authService.login` → error view.
- `pnpm quality` green (typecheck, lint, test, format, audit).

## Before using it
1. `pnpm --filter @pinsquirrel/crypto keygen` per environment; set each `EMAIL_PUBLIC_KEY` on the corresponding app server so signups start sealing.
2. Copy `admin.config.example.json` → `admin.config.json`, fill in each environment, and point `privateKeyPath` at the matching private key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an admin web app with environment selection, admin login, private-key unlock (including passphrase support), waitlist viewing, message composition, bulk email sending with per-recipient results, and logout.
  * Added an admin example configuration and a runnable local startup workflow, plus dev/lint tooling.
* **Bug Fixes**
  * Strengthened configuration validation with clearer error messages and duplicate environment detection.
  * Improved bulk sending resiliency with transient retry handling and continued delivery despite individual recipient failures.
* **Tests**
  * Added Vitest coverage for config parsing, key unlock flows, transient retry classification, mailer behavior, and user status querying.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->