### PR TITLE
fix(deps): upgrade @hono/node-server to 2.x (path traversal fix)

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -16,7 +16,7 @@
     "test:coverage": "vitest --run --coverage"
   },
   "dependencies": {
-    "@hono/node-server": "^1.19.13",
+    "@hono/node-server": "^2.0.11",
     "@pinsquirrel/crypto": "workspace:*",
     "@pinsquirrel/database": "workspace:*",
     "@pinsquirrel/domain": "workspace:*",

--- a/apps/hono/package.json
+++ b/apps/hono/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@hono/mcp": "^0.2.5",
-    "@hono/node-server": "^1.19.13",
+    "@hono/node-server": "^2.0.11",
     "@hono/zod-openapi": "^1.3.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@pinsquirrel/adapters": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
       "form-data": ">=4.0.6",
       "fast-uri": ">=4.1.1",
       "qs": ">=6.15.2",
-      "ip-address": ">=10.1.1"
+      "ip-address": ">=10.1.1",
+      "@hono/node-server": ">=2.0.5"
     }
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   fast-uri: '>=4.1.1'
   qs: '>=6.15.2'
   ip-address: '>=10.1.1'
+  '@hono/node-server': '>=2.0.5'
 
 importers:
 
@@ -45,8 +46,8 @@ importers:
   apps/admin:
     dependencies:
       '@hono/node-server':
-        specifier: ^1.19.13
-        version: 1.19.13(hono@4.12.32)
+        specifier: '>=2.0.5'
+        version: 2.0.11(hono@4.12.32)
       '@pinsquirrel/crypto':
         specifier: workspace:*
         version: link:../../libs/crypto
@@ -109,8 +110,8 @@ importers:
         specifier: ^0.2.5
         version: 0.2.5(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(hono-rate-limiter@0.4.2(hono@4.12.32))(hono@4.12.32)(zod@4.3.6)
       '@hono/node-server':
-        specifier: ^1.19.13
-        version: 1.19.13(hono@4.12.32)
+        specifier: '>=2.0.5'
+        version: 2.0.11(hono@4.12.32)
       '@hono/zod-openapi':
         specifier: ^1.3.0
         version: 1.3.0(hono@4.12.32)(zod@4.3.6)
@@ -947,9 +948,9 @@ packages:
       hono-rate-limiter: ^0.4.2
       zod: ^3.25.0 || ^4.0.0
 
-  '@hono/node-server@1.19.13':
-    resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
-    engines: {node: '>=18.14.1'}
+  '@hono/node-server@2.0.11':
+    resolution: {integrity: sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==}
+    engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
 
@@ -3497,7 +3498,7 @@ snapshots:
       pkce-challenge: 5.0.1
       zod: 4.3.6
 
-  '@hono/node-server@1.19.13(hono@4.12.32)':
+  '@hono/node-server@2.0.11(hono@4.12.32)':
     dependencies:
       hono: 4.12.32
 
@@ -3548,7 +3549,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.32)
+      '@hono/node-server': 2.0.11(hono@4.12.32)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5


### PR DESCRIPTION
Resolves the remaining `@hono/node-server` moderate advisory deferred from #54.

## Advisory

[GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9) — path traversal in the Hono Node.js adapter. Vulnerable `<2.0.5`; the only patched line is 2.x, so this is a **major version bump** (hence its own PR).

## Changes

- **Direct dep** `@hono/node-server` `^1.19.13 → ^2.0.11` in `apps/admin` and `apps/hono`.
- **Override** `"@hono/node-server": ">=2.0.5"` added to root `pnpm.overrides`. The vulnerable 1.x was also pulled in transitively via `@modelcontextprotocol/sdk`; without the override that copy lingered and the advisory stayed open. Everything now dedupes to `2.0.11`.

## Why this is low-risk despite being a major bump

Per the [v2.0.0 release notes](https://github.com/honojs/node-server/releases/tag/v2.0.0), the public API is unchanged — v2 is a performance rewrite (LightweightRequest/Response, up to 2.3x throughput). Our only API surface is `serve({ fetch, port })` and `serveStatic({ root })`, both unchanged. The Node engine requirement is `>=20`; this repo already requires `>=24`.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm build`, `pnpm format` all pass
- **Runtime boot check:** started the hono app on 2.x — `/health` returned `200` and `serveStatic` served `/static/htmx.min.js` at `200`, exercising both the `serve()` and static-file paths
- `pnpm audit --prod` now down to a single dev-only moderate (esbuild via drizzle-kit's deprecated `@esbuild-kit` chain), which stays below CI's `--audit-level=high` gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)