### PR TITLE
chore(deps): upgrade mailgun.js to 13.x

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -23,7 +23,7 @@
     "@pinsquirrel/services": "workspace:*",
     "dotenv": "^17.4.2",
     "hono": "^4.12.32",
-    "mailgun.js": "^12.7.1"
+    "mailgun.js": "^13.3.0"
   },
   "devDependencies": {
     "@eslint/js": "^10",

--- a/apps/hono/package.json
+++ b/apps/hono/package.json
@@ -36,7 +36,7 @@
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.32",
-    "mailgun.js": "^12.7.1",
+    "mailgun.js": "^13.3.0",
     "pino": "^10.3.1",
     "turndown": "^7.2.4"
   },

--- a/libs/mailgun/package.json
+++ b/libs/mailgun/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@pinsquirrel/domain": "workspace:*",
-    "mailgun.js": "^12.7.1"
+    "mailgun.js": "^13.3.0"
   },
   "devDependencies": {
     "@eslint/js": "^10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,7 +41,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@24.12.2)(happy-dom@18.0.1)(vite@6.3.6(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.2(@types/node@24.13.3)(happy-dom@18.0.1)(vite@6.3.6(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))
 
   apps/admin:
     dependencies:
@@ -67,8 +67,8 @@ importers:
         specifier: ^4.12.32
         version: 4.12.32
       mailgun.js:
-        specifier: ^12.7.1
-        version: 12.7.1
+        specifier: ^13.3.0
+        version: 13.3.0
     devDependencies:
       '@eslint/js':
         specifier: ^10
@@ -152,8 +152,8 @@ importers:
         specifier: ^4.12.32
         version: 4.12.32
       mailgun.js:
-        specifier: ^12.7.1
-        version: 12.7.1
+        specifier: ^13.3.0
+        version: 13.3.0
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -356,8 +356,8 @@ importers:
         specifier: workspace:*
         version: link:../domain
       mailgun.js:
-        specifier: ^12.7.1
-        version: 12.7.1
+        specifier: ^13.3.0
+        version: 13.3.0
     devDependencies:
       '@eslint/js':
         specifier: ^10
@@ -2714,8 +2714,8 @@ packages:
   magicast@0.5.2:
     resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
 
-  mailgun.js@12.7.1:
-    resolution: {integrity: sha512-VG2zRx4hKVoLGdMDpF5Bt+lkhS6g+eWb547FR4/iozoGEszcT+uf8/0EsPBwnpfI2gYlui3aaPnQCzcFDYvGXQ==}
+  mailgun.js@13.3.0:
+    resolution: {integrity: sha512-8avnVhhaZJ17Pw91nPq+N4WuhCBBi9SJpsiAs5SV0CmLXZhz0UobTGP5p3bVTI+Zh1NZU6nXtL+N8KM/taBX4w==}
     engines: {node: '>=18.0.0'}
 
   make-dir@4.0.0:
@@ -4451,6 +4451,14 @@ snapshots:
     optionalDependencies:
       vite: 6.3.6(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)
 
+  '@vitest/mocker@4.1.2(vite@6.3.6(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.2
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.3.6(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)
+
   '@vitest/pretty-format@4.1.2':
     dependencies:
       tinyrainbow: 3.1.0
@@ -5401,7 +5409,7 @@ snapshots:
       '@babel/types': 7.29.0
       source-map-js: 1.2.1
 
-  mailgun.js@12.7.1:
+  mailgun.js@13.3.0:
     dependencies:
       axios: 1.18.1
       base-64: 1.0.0
@@ -6105,6 +6113,22 @@ snapshots:
       tsx: 4.23.1
       yaml: 2.9.0
 
+  vite@6.3.6(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.22
+      rollup: 4.62.2
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.13.3
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      tsx: 4.23.1
+      yaml: 2.9.0
+
   vitest@4.1.2(@types/node@24.12.2)(happy-dom@18.0.1)(vite@6.3.6(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.2
@@ -6129,6 +6153,34 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.2
+      happy-dom: 18.0.1
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.2(@types/node@24.13.3)(happy-dom@18.0.1)(vite@6.3.6(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.2
+      '@vitest/mocker': 4.1.2(vite@6.3.6(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/runner': 4.1.2
+      '@vitest/snapshot': 4.1.2
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 6.3.6(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.23.1)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.13.3
       happy-dom: 18.0.1
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
Major upgrade of `mailgun.js` `^12.7.1 → ^13.3.0` across `libs/mailgun`, `apps/hono`, and `apps/admin`. Branched off `main` after #55 and #56 merged.

## Why this major bump is safe for us

The [only breaking change in 13.0.0](https://github.com/mailgun/mailgun.js/releases/tag/v13.0.0) is the removal of the optional `address` property from the query parameter of `MailingLists.list`. This codebase uses mailgun.js purely for transactional email — only `new Mailgun(FormData)`, `mailgun.client({...})`, and `client.messages.create(domain, data)`. There is **no mailing-list usage anywhere**, so the break doesn't apply.

Everything else in 13.x is additive (new API-keys client, account management, mailing-list members, etc.).

## Dependency note

`mailgun.js` pulls `axios` transitively. The existing `pnpm.overrides` entry (`axios: ">=1.18.0"`) still holds — axios resolves to `1.18.1` — so `pnpm audit` stays clean at the high gate.

## Verification

- `pnpm typecheck` — validates our call sites against 13.x's shipped type definitions
- `pnpm test` — the mailgun email-service and admin mailer suites (mocked client contract) pass
- `pnpm lint`, `pnpm build`, `pnpm format` — all pass
- `pnpm audit --prod` — unchanged (clean at high)

🤖 Generated with [Claude Code](https://claude.com/claude-code)