### PR TITLE
chore(deps): upgrade @hono/mcp to 0.3.x

### DIFF
--- a/apps/hono/package.json
+++ b/apps/hono/package.json
@@ -21,7 +21,7 @@
     "grant-admin": "tsx src/scripts/grant-admin.ts"
   },
   "dependencies": {
-    "@hono/mcp": "^0.2.5",
+    "@hono/mcp": "^0.3.1",
     "@hono/node-server": "^2.0.11",
     "@hono/zod-openapi": "^1.5.1",
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,11 @@
       "qs": ">=6.15.2",
       "ip-address": ">=10.1.1",
       "@hono/node-server": ">=2.0.5"
+    },
+    "peerDependencyRules": {
+      "allowedVersions": {
+        "@hono/mcp>hono-rate-limiter": "0.4.2"
+      }
     }
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,8 +107,8 @@ importers:
   apps/hono:
     dependencies:
       '@hono/mcp':
-        specifier: ^0.2.5
-        version: 0.2.5(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(hono-rate-limiter@0.4.2(hono@4.12.32))(hono@4.12.32)(zod@4.4.3)
+        specifier: ^0.3.1
+        version: 0.3.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(hono-rate-limiter@0.4.2(hono@4.12.32))(hono@4.12.32)(zod@4.4.3)
       '@hono/node-server':
         specifier: '>=2.0.5'
         version: 2.0.11(hono@4.12.32)
@@ -1096,12 +1096,12 @@ packages:
     resolution: {integrity: sha512-ejvBr8MQCbVsWNZnCwDXjUKq40MDmHalq7cJ6e9s/qzTUFIIo/afzt1Vui9T97FM/V/pN4YsFVoed5NIa96RDg==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@hono/mcp@0.2.5':
-    resolution: {integrity: sha512-JsaJes7VlNvUrUQ9j2b9C13xjFLvyKQY515aWtsdJ9cwhBmWz5od2yUCbDu7cX38GeADmlLmpu4BKNNAV6G27w==}
+  '@hono/mcp@0.3.1':
+    resolution: {integrity: sha512-EB2rTyyl27qT8KtvEysgfcLK2jhp4KBb5+XyJ5/bcKNA64usp6qyuUWja9X4QB8Rx9U/yhZHGpfI96Xa/jem4Q==}
     peerDependencies:
-      '@modelcontextprotocol/sdk': ^1.25.1
+      '@modelcontextprotocol/sdk': ^1.29.0
       hono: '*'
-      hono-rate-limiter: ^0.4.2
+      hono-rate-limiter: ^0.5.3
       zod: ^3.25.0 || ^4.0.0
 
   '@hono/node-server@2.0.11':
@@ -3881,7 +3881,7 @@ snapshots:
       '@eslint/core': 1.2.0
       levn: 0.4.1
 
-  '@hono/mcp@0.2.5(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(hono-rate-limiter@0.4.2(hono@4.12.32))(hono@4.12.32)(zod@4.4.3)':
+  '@hono/mcp@0.3.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(hono-rate-limiter@0.4.2(hono@4.12.32))(hono@4.12.32)(zod@4.4.3)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       hono: 4.12.32


### PR DESCRIPTION
Upgrades `@hono/mcp` `^0.2.5 → ^0.3.1` in `apps/hono`. Branched off `main` after #57 merged.

## Why the bump is backward-compatible

The [0.3.0 change](https://github.com/honojs/middleware/blob/main/packages/mcp/CHANGELOG.md) is additive: it *relaxes* Accept-header validation (now accepts `application/json`, `text/event-stream`, or `*/*` individually) and adds an optional `strictAcceptHeader` flag. Our only usage is `new StreamableHTTPTransport({ sessionIdGenerator, enableJsonResponse })` — unaffected.

## The `hono-rate-limiter` peer, and why we don't chase it

0.3.1 raises its `hono-rate-limiter` peer from `^0.4.2` to `^0.5.3`. Investigation:

- `hono-rate-limiter` is referenced **only** in `@hono/mcp`'s `auth.*` module (the OAuth auth-router, `@hono/mcp/auth`) — **not** in `index.*` where `StreamableHTTPTransport` lives.
- This app never imports `@hono/mcp/auth`; MCP auth is our own bearer-auth middleware. So that peer never loads on our code path.
- Bumping `hono-rate-limiter` to `0.5.3` would only make things worse — it introduces a **new** unmet `unstorage` peer.

So we keep `hono-rate-limiter` at `0.4.2` and acknowledge the mismatch precisely via `pnpm.peerDependencyRules` scoped to `@hono/mcp>hono-rate-limiter`, keeping installs warning-free without silencing unrelated peers.

## Node-server override

The MCP SDK stays at `1.29.0`, so it still transitively wants `@hono/node-server` 1.x — the existing override (`>=2.0.5`) is **still required** and left in place. (This bump did not let us drop it, contrary to the earlier hypothesis.)

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm build`, `pnpm format`, `pnpm audit` — all pass
- `pnpm install --frozen-lockfile` — passes (CI-safe)
- **Runtime:** app boots on 0.3.1 with no import errors; `POST /mcp` returns `401` for unauthenticated and bad-token requests, confirming the route + `mcpAuth` + `StreamableHTTPTransport` load and wire correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)