### PR TITLE
chore(deps): upgrade @scalar/hono-api-reference to 0.11.x

### DIFF
--- a/apps/hono/package.json
+++ b/apps/hono/package.json
@@ -31,7 +31,7 @@
     "@pinsquirrel/domain": "workspace:*",
     "@pinsquirrel/mailgun": "workspace:*",
     "@pinsquirrel/services": "workspace:*",
-    "@scalar/hono-api-reference": "^0.10.8",
+    "@scalar/hono-api-reference": "^0.11.11",
     "cheerio": "^1.2.0",
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.45.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,8 +137,8 @@ importers:
         specifier: workspace:*
         version: link:../../libs/services
       '@scalar/hono-api-reference':
-        specifier: ^0.10.8
-        version: 0.10.8(hono@4.12.32)
+        specifier: ^0.11.11
+        version: 0.11.11(hono@4.12.32)
       cheerio:
         specifier: ^1.2.0
         version: 1.2.0
@@ -1507,27 +1507,31 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@scalar/client-side-rendering@0.1.1':
-    resolution: {integrity: sha512-ACASA/nQAC6HXQTIkkBlvCFxUN9xfCy3Zdgo75rw8jzUqsxRIpTuucR7r9VW1bO/N4qsgEQumC4hK4ESCMdZmQ==}
+  '@scalar/client-side-rendering@0.3.4':
+    resolution: {integrity: sha512-kb3B+FGjvAUr2DU0fe9dVKBLwot1TjOO+iHCTmY8r8FUJySmYKGQYCicRzzilOyTjvKspiZBCEr03PWaWW+1gw==}
     engines: {node: '>=22'}
 
-  '@scalar/core@0.5.1':
-    resolution: {integrity: sha512-LvH4m502KjEICn7d6lG28fU2TT5AIAJN/czpnx1wusLei2EAgVeEfy0Gkr/kQy+lU215fockVngcvOktYb6KrA==}
+  '@scalar/helpers@0.9.2':
+    resolution: {integrity: sha512-hjyMpMZjTBZQhyByZmz5oUgRKUQJO5V5AOiJxsVEGbUmgA7sJRQeTrXLB+BEwzaKS5nm2opJeNyMBYLFNK4hiQ==}
     engines: {node: '>=22'}
 
-  '@scalar/helpers@0.5.0':
-    resolution: {integrity: sha512-S7m46UWqngUmDXuihUerNKS58vlUqF/qaXle3QREfc8Xh9wperAKxFmmxrnulAayrcCQ/fTJyGu5oSM2STlxkA==}
-    engines: {node: '>=22'}
-
-  '@scalar/hono-api-reference@0.10.8':
-    resolution: {integrity: sha512-/8Pfg1ijyiL0gypc85geh7xFl0+iLUQS0tcqrX5cdao7pRO+aiDreMxYOBcRD9MJRD++nFUVYla97nmNwoTRTQ==}
+  '@scalar/hono-api-reference@0.11.11':
+    resolution: {integrity: sha512-yvJ2oqyG9MC4C55/Xvi/Jny5qBYDxDvoVleABhgNG24A93u9ar17qsdSppli94sQOUdX31Qw/yCTm89LHbBRiQ==}
     engines: {node: '>=22'}
     peerDependencies:
       hono: ^4.12.5
 
-  '@scalar/types@0.9.0':
-    resolution: {integrity: sha512-SJNI2f2ZEsN+Cp7o4rAjPu2nFRFXdSkO1ocG9rzynhJhbMBniHnbkCAe19QT/iHMvSCXfj8J8qDOn2S+TnMymg==}
+  '@scalar/schemas@0.7.4':
+    resolution: {integrity: sha512-Or31zxR+ceGGhkVU5XBO2Zv7oyGDtjsJOjM2Rr0WRZ1/tRsQc2/FsVv+9kPmCA7sqFL8BKWlNfTXcPITI7WRHw==}
     engines: {node: '>=22'}
+
+  '@scalar/types@0.16.4':
+    resolution: {integrity: sha512-fLf0ANAC3iQq0sIVdmH6aGM+pFSLyD8GfGBxSWcLpI0jE0iFAzX2A3p0qVZm7vqBT4TQnn0fSwg5U+h+FZ52BA==}
+    engines: {node: '>=22'}
+
+  '@scalar/validation@0.6.2':
+    resolution: {integrity: sha512-Sc1TkcwGV6aVCO51AyKeaGiP8gpwAHxEtO5d3tZzPV+KsnlC/YokQxFxwBrbIXw73k9hmcExnJyGu3k5i6n6VA==}
+    engines: {node: '>=20'}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -2786,8 +2790,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.1.9:
-    resolution: {integrity: sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==}
+  nanoid@5.1.16:
+    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -3312,8 +3316,8 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
-  type-fest@5.5.0:
-    resolution: {integrity: sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==}
+  type-fest@5.8.0:
+    resolution: {integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==}
     engines: {node: '>=20'}
 
   type-is@2.0.1:
@@ -4174,28 +4178,32 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
-  '@scalar/client-side-rendering@0.1.1':
+  '@scalar/client-side-rendering@0.3.4':
     dependencies:
-      '@scalar/types': 0.9.0
+      '@scalar/schemas': 0.7.4
+      '@scalar/types': 0.16.4
+      '@scalar/validation': 0.6.2
 
-  '@scalar/core@0.5.1':
+  '@scalar/helpers@0.9.2': {}
+
+  '@scalar/hono-api-reference@0.11.11(hono@4.12.32)':
     dependencies:
-      '@scalar/client-side-rendering': 0.1.1
-      '@scalar/types': 0.9.0
-
-  '@scalar/helpers@0.5.0': {}
-
-  '@scalar/hono-api-reference@0.10.8(hono@4.12.32)':
-    dependencies:
-      '@scalar/core': 0.5.1
+      '@scalar/client-side-rendering': 0.3.4
       hono: 4.12.32
 
-  '@scalar/types@0.9.0':
+  '@scalar/schemas@0.7.4':
     dependencies:
-      '@scalar/helpers': 0.5.0
-      nanoid: 5.1.9
-      type-fest: 5.5.0
+      '@scalar/helpers': 0.9.2
+      '@scalar/validation': 0.6.2
+
+  '@scalar/types@0.16.4':
+    dependencies:
+      '@scalar/helpers': 0.9.2
+      nanoid: 5.1.16
+      type-fest: 5.8.0
       zod: 4.4.3
+
+  '@scalar/validation@0.6.2': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -5481,7 +5489,7 @@ snapshots:
 
   nanoid@3.3.16: {}
 
-  nanoid@5.1.9: {}
+  nanoid@5.1.16: {}
 
   natural-compare@1.4.0: {}
 
@@ -6052,7 +6060,7 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  type-fest@5.5.0:
+  type-fest@5.8.0:
     dependencies:
       tagged-tag: 1.0.0
 


### PR DESCRIPTION
Upgrades `@scalar/hono-api-reference` `^0.10.8 → ^0.11.11` in `apps/hono`. Branched off `main` after #58 merged. This is the last item from the earlier production-dependency assessment.

## Why the bump is backward-compatible

The only feature change across the 0.11 line is additive — [0.11.0](https://github.com/scalar/scalar/blob/main/integrations/hono/CHANGELOG.md) adds an optional `nonce` option for stricter CSP `script-src` support. Everything from 0.11.1 → 0.11.11 is patch-level (README / republish fixes). Our single usage — `Scalar({ url: '/api/openapi.json' })` in `apps/hono/src/routes/api-docs.ts` — is unchanged.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm build`, `pnpm format`, `pnpm audit` — all pass
- `pnpm install --frozen-lockfile` — passes (CI-safe), no peer warnings
- **Runtime:** app boots cleanly; `GET /api/docs` returns `200` with the Scalar reference UI rendered; `GET /api/openapi.json` serves a valid OpenAPI `3.1.0` spec with the expected `/v1/*` paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)