### PR TITLE
chore(deps): ignore two broken upstream releases in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,19 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
+    ignore:
+      # 1.5.2 ships broken type declarations: the `z` re-export resolves to an
+      # error type, so @typescript-eslint's type-aware rules report 23 errors
+      # in apps/hono/src/routes/api-v1.ts. tsc itself is fine; only the
+      # type-aware lint rules notice. Declared deps are identical to 1.5.1, so
+      # this is a regression in the published .d.ts. Exact-version ignore so
+      # 1.5.3+ is still offered.
+      - dependency-name: '@hono/zod-openapi'
+        versions: ['1.5.2']
+      # TypeScript 7 is unsupported by every released typescript-eslint —
+      # 8.67.0 (latest) still declares peer typescript '>=4.8.4 <6.1.0', and
+      # typescript-estree crashes with "Cannot read properties of undefined
+      # (reading 'Cjs')" under TS 7. Drop this ignore once typescript-eslint
+      # ships TS 7 support.
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']


### PR DESCRIPTION
Enabling the npm ecosystem raised 5 Dependabot PRs. Two fail CI for reasons that will **recur on every future run** unless ignored — this adds those two ignore rules.

## The two ignores

**`@hono/zod-openapi` 1.5.2** — exact-version ignore.

Its `z` re-export resolves to an error type, so `@typescript-eslint`'s type-aware rules report 23 errors in `apps/hono/src/routes/api-v1.ts` (`no-unsafe-call`, `no-unsafe-member-access`, `no-unsafe-assignment` on `z.object`, `z.string`, `z.union`, `z.array`).

Worth noting: **`typecheck` passes — only `lint` fails.** `tsc` resolves the types fine; only the type-aware lint rules see the breakage. Declared dependencies are byte-identical between 1.5.1 and 1.5.2 (same `openapi3-ts`, `@hono/zod-validator`, `@asteasolutions/zod-to-openapi@^8.5.0`, same `zod: ^4.0.0` peer) and the same `zod@4.4.3` resolves in both — so this is a regression in the published `.d.ts`, not a resolution change on our side. Verified by pinning only that package back to 1.5.1 on the PR branch, which makes lint pass clean.

Pinned to the exact version so 1.5.3+ is still offered automatically.

**`typescript` majors** — ignore `version-update:semver-major`.

No released `typescript-eslint` supports TypeScript 7. The latest, 8.67.0, still declares peer `typescript: '>=4.8.4 <6.1.0'`, and `typescript-estree` crashes under TS 7 with `TypeError: Cannot read properties of undefined (reading 'Cjs')`. Minor and patch updates still flow; only the major is held. Drop this once typescript-eslint ships TS 7 support.

## What this does and doesn't fix

| PR | Status | Fixed by this? |
| --- | --- | --- |
| #64 production group (5 updates) | ❌ `quality` fails | ✅ after merge, `@dependabot recreate` rebuilds without 1.5.2 |
| #67 typescript 6→7 | ❌ `quality` fails | ✅ Dependabot closes it |
| #65 dev group (5 updates) | ❌ `quality` fails | ❌ **needs a code commit, not config** — prettier 3.9.6 and typescript-eslint 8.66 changed their output; the fix is `pnpm format` + `eslint --fix` |
| #66 concurrently 9→10 | ✅ passing | n/a — mergeable now |
| #68 @types/node 24→26 | ✅ passing | n/a — mergeable now |

## Verification

`.github/dependabot.yml` parses as valid YAML with both ignore entries and both groups intact; `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)