### PR TITLE
chore(deps): drop the now-redundant shell-quote override

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
       "@hono/node-server": ">=2.0.5",
       "@esbuild-kit/core-utils>esbuild": "^0.25.0",
       "body-parser": ">=2.3.0",
-      "shell-quote": ">=1.9.0",
       "brace-expansion": ">=5.0.9",
       "postcss": ">=8.5.23",
       "happy-dom": ">=20.8.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,6 @@ overrides:
   '@hono/node-server': '>=2.0.5'
   '@esbuild-kit/core-utils>esbuild': ^0.25.0
   body-parser: '>=2.3.0'
-  shell-quote: '>=1.9.0'
   brace-expansion: '>=5.0.9'
   postcss: '>=8.5.23'
   happy-dom: '>=20.8.9'
@@ -2828,8 +2827,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.10.0:
-    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
+  shell-quote@1.9.0:
+    resolution: {integrity: sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==}
     engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.1:
@@ -4228,7 +4227,7 @@ snapshots:
     dependencies:
       chalk: 5.6.2
       rxjs: 7.8.2
-      shell-quote: 1.10.0
+      shell-quote: 1.9.0
       supports-color: 10.2.2
       tree-kill: 1.2.2
       yargs: 18.0.0
@@ -5347,7 +5346,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.10.0: {}
+  shell-quote@1.9.0: {}
 
   side-channel-list@1.0.1:
     dependencies:


### PR DESCRIPTION
The `shell-quote` override was added when `concurrently` 9.2.1 pinned it to exactly 1.8.3, which was vulnerable and had no upgrade path. Now that #66 landed `concurrently` 10.0.4 — which depends on `shell-quote` 1.9.0 directly — the override no longer does anything except force a newer patch than the dependency asks for.

## Note: this is a downgrade, and that's fine

`concurrently` declares `shell-quote: 1.9.0` as an **exact pin**, not a range, and it is the only consumer in the tree. So removing the override resolves 1.10.0 → **1.9.0**.

That is still fully patched. Per the GitHub Advisory Database:

| Severity | Advisory | Patched in |
| --- | --- | --- |
| HIGH | Quadratic-complexity DoS in `parse()` | **1.9.0** |
| CRITICAL | `quote()` does not escape newlines in object `.op` values | 1.8.4 |
| CRITICAL | Improper neutralization of special elements in a command | 1.7.3 |
| CRITICAL | Potential command injection | 1.6.1 |

1.9.0 clears all four.

## Verification

Run locally against a real MySQL container:

| Command | Result |
| --- | --- |
| `pnpm typecheck` | 8/8 successful |
| `pnpm lint` | 8/8 successful |
| `pnpm test` | 8/8 successful |
| `pnpm build` | successful |
| `pnpm format` | successful, no files changed |
| `pnpm run audit` (prod) | No known vulnerabilities found |
| `pnpm audit` (full, dev included) | No known vulnerabilities found |

Diff is one line of `package.json` plus the lockfile following it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a dependency version override from the project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->