### PR TITLE
fix: run lint-staged from local node_modules in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpx lint-staged
+pnpm exec lint-staged


### PR DESCRIPTION
## Problem

`.husky/pre-commit` was a bare `pnpx lint-staged`. In pnpm 11, `pnpx` is an alias for `pnpm dlx` — *"Run a package in a temporary environment."* It resolves and fetches from the registry, ignoring the workspace's `node_modules` entirely.

The pinned devDependency therefore never governed what the hook ran. Verified on `main` while it still pinned `^16.4.0`:

```
$ pnpx lint-staged --version
17.3.0
```

So every commit had already been running lint-staged 17.x, regardless of the declared 16.x pin.

## Why it matters

- **The pin was decorative.** `pnpm-lock.yaml` had no authority over the pre-commit path, so the version could drift under you at any time without a lockfile change or a PR.
- **Supply chain.** Every developer commit resolved and downloaded a package from the network rather than using the audited, lockfile-pinned copy — putting the hook outside the coverage of both the lockfile and `pnpm run audit`.
- **Offline/CI-sandbox commits** depend on network reachability and the dlx cache.

## Fix

```diff
-pnpx lint-staged
+pnpm exec lint-staged
```

`pnpm exec` runs `node_modules/.bin/lint-staged` — the copy pnpm installed from the lockfile — making the declared version authoritative and the hook offline-safe.

## Verification

- `pnpm exec lint-staged --version` → `17.3.0`, resolving to `node_modules/.bin/lint-staged` (now matching the `^17.3.0` pin from #79)
- Committing this change ran the new hook itself; it correctly reported no matching staged files
- End-to-end: staged a deliberately misformatted `.md`, ran `sh .husky/pre-commit` — prettier reformatted it and re-staged the result
- `pnpm quality` passes (typecheck, lint, test, format, audit)

Found while reviewing #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pre-commit workflow to run staged-file checks more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->