### PR TITLE
chore(deps): drop the dead hono-rate-limiter peerDependencyRules allowance

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,3 @@ overrides:
   happy-dom: '>=20.8.9'
   tsup>esbuild: ^0.28.1
   bundle-require>esbuild: ^0.28.1
-
-peerDependencyRules:
-  allowedVersions:
-    '@hono/mcp>hono-rate-limiter': 0.4.2


### PR DESCRIPTION
## What

Removes the now-inert `peerDependencyRules` block from `pnpm-workspace.yaml`:

```diff
-peerDependencyRules:
-  allowedVersions:
-    '@hono/mcp>hono-rate-limiter': 0.4.2
```

## Why

The allowance existed so `@hono/mcp` would accept `hono-rate-limiter@0.4.2` when its declared peer range was narrower than what resolved. That situation is gone — `@hono/mcp@0.3.1` now declares:

```yaml
peerDependencies:
  hono-rate-limiter: ^0.5.3
```

and 0.5.3 is what the lockfile resolves. The rule permits a version nothing asks for.

## Verification

Confirmed inert rather than assumed — removed the block, then ran both `pnpm install --lockfile-only` and a forced full re-resolve:

- zero-line `pnpm-lock.yaml` diff
- no peer-dependency warnings
- `pnpm exec turbo test typecheck lint --force` → 24/24 tasks pass with cache disabled
- `pnpm run audit` clean

## Also clears two stale PLAN.md follow-ups

Phase 6f carried a three-clause item; all three are resolved:

| Clause | Status |
|---|---|
| Bump `hono-rate-limiter` to `^0.5.3` | already satisfied transitively via `@hono/mcp@0.3.1` |
| Handle its `unstorage` peer | non-issue — 0.5.3 marks `unstorage` **optional** in `peerDependenciesMeta` |
| Remove the `peerDependencyRules` allowance | **this PR** |

What actually remains in 6f is only extending `rate-limit.ts` coverage to `/mcp`, `/api/v1/*`, `/oauth/token`, and `/oauth/register`. A follow-up PR updates PLAN.md accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)