### PR TITLE
test: characterize the pin routes ahead of deduplication

### DIFF
--- a/apps/hono/src/routes/pins.test.tsx
+++ b/apps/hono/src/routes/pins.test.tsx
@@ -1,0 +1,530 @@
+/**
+ * Characterization tests for the public pin routes.
+ *
+ * These pin down current behavior ahead of deduplicating `pins.tsx` and
+ * `private.tsx`, which share 558 identical lines. They assert what the code
+ * does today, not what it ought to do — where behavior looks questionable it is
+ * captured and labelled rather than corrected, so the refactor stays provably
+ * behavior-preserving.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+import type { MiddlewareHandler } from 'hono'
+import {
+  Pagination,
+  DuplicatePinError,
+  ValidationError,
+  PinNotFoundError,
+  UnauthorizedPinAccessError,
+} from '@pinsquirrel/domain'
+import {
+  testUser,
+  makePin,
+  makeTag,
+  createServiceMocks,
+  createSessionMocks,
+  fakeSessionManager,
+  formBody,
+} from '../test-support/pin-routes'
+
+const svc = createServiceMocks()
+const session = createSessionMocks()
+
+vi.mock('../lib/services', () => ({
+  pinService: {
+    getPin: (...a: unknown[]) => svc.getPin(...a) as unknown,
+    createPin: (...a: unknown[]) => svc.createPin(...a) as unknown,
+    updatePin: (...a: unknown[]) => svc.updatePin(...a) as unknown,
+    deletePin: (...a: unknown[]) => svc.deletePin(...a) as unknown,
+    getUserPinsWithPagination: (...a: unknown[]) =>
+      svc.getUserPinsWithPagination(...a) as unknown,
+  },
+  tagService: {
+    getUserTags: (...a: unknown[]) => svc.getUserTags(...a) as unknown,
+  },
+}))
+
+vi.mock('../middleware/session', () => ({
+  requireAuth: (): MiddlewareHandler => async (_c, next) => {
+    await next()
+  },
+  getSessionManager: () => fakeSessionManager(session),
+}))
+
+import { pinsRoutes } from './pins'
+
+describe('pins routes', () => {
+  let app: Hono
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    session.getUser.mockResolvedValue(testUser)
+    session.getFlash.mockReturnValue(null)
+    svc.getUserTags.mockResolvedValue([makeTag()])
+    svc.getUserPinsWithPagination.mockResolvedValue({
+      pins: [makePin()],
+      pagination: Pagination.fromTotalCount(1),
+    })
+    app = new Hono()
+    app.route('/pins', pinsRoutes)
+  })
+
+  describe('GET / — list', () => {
+    it('renders the list and excludes private pins from the filter', async () => {
+      const res = await app.request('/pins')
+
+      expect(res.status).toBe(200)
+      expect(await res.text()).toContain('Example Pin')
+
+      const filter = svc.getUserPinsWithPagination.mock.calls[0][1]
+      expect(filter).toMatchObject({ isPrivate: false })
+    })
+
+    it('uses a fixed page size of 25', async () => {
+      await app.request('/pins')
+
+      expect(svc.getUserPinsWithPagination.mock.calls[0][2]).toEqual({
+        page: 1,
+        pageSize: 25,
+      })
+    })
+
+    it('maps query params onto the filter', async () => {
+      await app.request('/pins?tag=foo&search=box&notags=true&page=3')
+
+      const [, filter, options] = svc.getUserPinsWithPagination.mock.calls[0]
+      expect(filter).toMatchObject({
+        isPrivate: false,
+        tag: 'foo',
+        search: 'box',
+        noTags: true,
+      })
+      expect(options).toMatchObject({ page: 3 })
+    })
+
+    it('maps unread=true/false onto readLater, and omits it otherwise', async () => {
+      await app.request('/pins?unread=true')
+      expect(svc.getUserPinsWithPagination.mock.calls[0][1]).toMatchObject({
+        readLater: true,
+      })
+
+      svc.getUserPinsWithPagination.mockClear()
+      await app.request('/pins?unread=false')
+      expect(svc.getUserPinsWithPagination.mock.calls[0][1]).toMatchObject({
+        readLater: false,
+      })
+
+      svc.getUserPinsWithPagination.mockClear()
+      await app.request('/pins')
+      expect(svc.getUserPinsWithPagination.mock.calls[0][1]).not.toHaveProperty(
+        'readLater'
+      )
+    })
+
+    it('defaults sorting to created/desc and honours overrides', async () => {
+      await app.request('/pins')
+      expect(svc.getUserPinsWithPagination.mock.calls[0][1]).toMatchObject({
+        sortBy: 'created',
+        sortDirection: 'desc',
+      })
+
+      svc.getUserPinsWithPagination.mockClear()
+      await app.request('/pins?sort=title&direction=asc')
+      expect(svc.getUserPinsWithPagination.mock.calls[0][1]).toMatchObject({
+        sortBy: 'title',
+        sortDirection: 'asc',
+      })
+    })
+
+    it('returns only the content partial for HTMX requests', async () => {
+      const full = await app.request('/pins')
+      const partial = await app.request('/pins', {
+        headers: { 'HX-Request': 'true' },
+      })
+
+      const fullHtml = await full.text()
+      const partialHtml = await partial.text()
+
+      expect(partial.status).toBe(200)
+      expect(partialHtml).toContain('Example Pin')
+      expect(partialHtml.length).toBeLessThan(fullHtml.length)
+    })
+  })
+
+  describe('GET /new — create form', () => {
+    it('renders the form', async () => {
+      const res = await app.request('/pins/new')
+      expect(res.status).toBe(200)
+      expect(await res.text()).toContain('form')
+    })
+
+    it('prefills from query params when the URL is not already saved', async () => {
+      svc.getUserPinsWithPagination.mockResolvedValue({
+        pins: [],
+        pagination: Pagination.fromTotalCount(0),
+      })
+
+      const res = await app.request(
+        '/pins/new?url=https%3A%2F%2Fx.test%2Fa&title=Hello&tag=foo'
+      )
+      const html = await res.text()
+
+      expect(res.status).toBe(200)
+      expect(html).toContain('https://x.test/a')
+      expect(html).toContain('Hello')
+    })
+
+    it('redirects to the existing pin when the URL is already saved', async () => {
+      // Bookmarklet dedup: a prefill URL that already exists sends the user to
+      // that pin's edit form instead of creating a duplicate.
+      svc.getUserPinsWithPagination.mockResolvedValue({
+        pins: [makePin({ id: 'pin-42' })],
+        pagination: Pagination.fromTotalCount(1),
+      })
+
+      const res = await app.request('/pins/new?url=https%3A%2F%2Fx.test%2Fa')
+
+      expect(res.status).toBe(302)
+      expect(res.headers.get('Location')).toBe('/pins/pin-42/edit')
+      expect(svc.getUserPinsWithPagination.mock.calls[0][1]).toEqual({
+        url: 'https://x.test/a',
+      })
+    })
+
+    it('skips the dedup lookup when no url param is supplied', async () => {
+      await app.request('/pins/new')
+
+      expect(svc.getUserPinsWithPagination).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('POST /new — create', () => {
+    it('creates a pin and redirects to the list', async () => {
+      svc.createPin.mockResolvedValue(makePin())
+
+      const res = await app.request(
+        '/pins/new',
+        formBody({
+          url: 'https://x.test/a',
+          title: 'Hello',
+          description: 'Desc',
+          tags: 'foo, bar',
+        })
+      )
+
+      expect(res.status).toBe(302)
+      expect(res.headers.get('Location')).toBe('/pins')
+      expect(svc.createPin).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          userId: testUser.id,
+          url: 'https://x.test/a',
+          title: 'Hello',
+          description: 'Desc',
+          tagNames: ['foo', 'bar'],
+        })
+      )
+    })
+
+    it('reads isPrivate from the submitted form', async () => {
+      svc.createPin.mockResolvedValue(makePin())
+
+      await app.request(
+        '/pins/new',
+        formBody({ url: 'https://x.test/a', title: 'T', isPrivate: 'true' })
+      )
+
+      expect(svc.createPin.mock.calls[0][1]).toMatchObject({ isPrivate: true })
+    })
+
+    it('treats readLater as true only for the literal string "true"', async () => {
+      svc.createPin.mockResolvedValue(makePin())
+
+      await app.request(
+        '/pins/new',
+        formBody({ url: 'https://x.test/a', title: 'T', readLater: 'on' })
+      )
+
+      expect(svc.createPin.mock.calls[0][1]).toMatchObject({ readLater: false })
+    })
+
+    it('drops empty tags and trims whitespace', async () => {
+      svc.createPin.mockResolvedValue(makePin())
+
+      await app.request(
+        '/pins/new',
+        formBody({ url: 'https://x.test/a', title: 'T', tags: ' foo , , bar ' })
+      )
+
+      expect(svc.createPin.mock.calls[0][1]).toMatchObject({
+        tagNames: ['foo', 'bar'],
+      })
+    })
+
+    it('sets a success flash on create', async () => {
+      svc.createPin.mockResolvedValue(makePin())
+
+      await app.request(
+        '/pins/new',
+        formBody({ url: 'https://x.test/a', title: 'T' })
+      )
+
+      expect(session.setFlash).toHaveBeenCalledWith(
+        'success',
+        expect.stringContaining('created')
+      )
+    })
+
+    it('re-renders the form without redirecting when the URL is a duplicate', async () => {
+      svc.createPin.mockRejectedValue(new DuplicatePinError('https://x.test/a'))
+
+      const res = await app.request(
+        '/pins/new',
+        formBody({ url: 'https://x.test/a', title: 'T' })
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.headers.get('Location')).toBeNull()
+    })
+
+    it('re-renders the form on a validation error', async () => {
+      svc.createPin.mockRejectedValue(new ValidationError({ url: ['invalid'] }))
+
+      const res = await app.request(
+        '/pins/new',
+        formBody({ url: 'nope', title: 'T' })
+      )
+
+      expect(res.status).toBe(200)
+    })
+
+    it('uses HX-Redirect instead of a 302 for HTMX submissions', async () => {
+      svc.createPin.mockResolvedValue(makePin())
+
+      const res = await app.request('/pins/new', {
+        ...formBody({ url: 'https://x.test/a', title: 'T' }),
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'HX-Request': 'true',
+        },
+      })
+
+      expect(res.status).toBe(200)
+      expect(res.headers.get('HX-Redirect')).toBe('/pins')
+    })
+  })
+
+  describe('GET /:id/edit — edit form', () => {
+    it('renders the form for an existing pin', async () => {
+      svc.getPin.mockResolvedValue(makePin({ title: 'Existing' }))
+
+      const res = await app.request('/pins/pin-1/edit')
+
+      expect(res.status).toBe(200)
+      expect(await res.text()).toContain('Existing')
+      expect(svc.getPin).toHaveBeenCalledWith(expect.anything(), 'pin-1')
+    })
+  })
+
+  describe('POST /:id/edit — update', () => {
+    beforeEach(() => {
+      svc.getPin.mockResolvedValue(makePin())
+      svc.updatePin.mockResolvedValue(makePin())
+    })
+
+    it('updates and redirects to the list', async () => {
+      const res = await app.request(
+        '/pins/pin-1/edit',
+        formBody({ url: 'https://x.test/b', title: 'Updated' })
+      )
+
+      expect(res.status).toBe(302)
+      expect(res.headers.get('Location')).toBe('/pins')
+      expect(svc.updatePin).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ id: 'pin-1', title: 'Updated' })
+      )
+    })
+
+    it('preserves list filters in the redirect target', async () => {
+      const res = await app.request(
+        '/pins/pin-1/edit?tag=foo&page=2',
+        formBody({ url: 'https://x.test/b', title: 'Updated' })
+      )
+
+      expect(res.headers.get('Location')).toBe('/pins?tag=foo&page=2')
+    })
+
+    it('takes userId from the existing pin, not the session', async () => {
+      svc.getPin.mockResolvedValue(makePin({ userId: 'owner-9' }))
+
+      await app.request(
+        '/pins/pin-1/edit',
+        formBody({ url: 'https://x.test/b', title: 'Updated' })
+      )
+
+      expect(svc.updatePin.mock.calls[0][1]).toMatchObject({
+        userId: 'owner-9',
+      })
+    })
+  })
+
+  describe('POST /:id/toggle-read', () => {
+    it('flips readLater and returns just the card', async () => {
+      svc.getPin.mockResolvedValue(makePin({ readLater: false }))
+      svc.updatePin.mockResolvedValue(makePin({ readLater: true }))
+
+      const res = await app.request('/pins/pin-1/toggle-read', {
+        method: 'POST',
+      })
+
+      expect(res.status).toBe(200)
+      expect(svc.updatePin.mock.calls[0][1]).toMatchObject({ readLater: true })
+
+      const html = await res.text()
+      expect(html).toContain('Example Pin')
+      expect(html).not.toContain('<html')
+    })
+
+    it('carries the referer query string into the re-rendered card', async () => {
+      svc.getPin.mockResolvedValue(makePin())
+      svc.updatePin.mockResolvedValue(makePin())
+
+      const res = await app.request('/pins/pin-1/toggle-read', {
+        method: 'POST',
+        headers: { Referer: 'https://app.test/pins?tag=foo' },
+      })
+
+      expect(await res.text()).toContain('tag=foo')
+    })
+
+    it('tolerates a malformed referer', async () => {
+      svc.getPin.mockResolvedValue(makePin())
+      svc.updatePin.mockResolvedValue(makePin())
+
+      const res = await app.request('/pins/pin-1/toggle-read', {
+        method: 'POST',
+        headers: { Referer: 'not-a-url' },
+      })
+
+      expect(res.status).toBe(200)
+    })
+  })
+
+  describe('GET /:id/delete-confirm — inline confirmation', () => {
+    it('returns the confirmation fragment', async () => {
+      svc.getPin.mockResolvedValue(makePin())
+
+      const res = await app.request('/pins/pin-1/delete-confirm')
+
+      expect(res.status).toBe(200)
+      expect(await res.text()).not.toContain('<html')
+    })
+
+    it('strips view from the delete action but keeps it on cancel', async () => {
+      // `view` is pulled out of the query string and passed separately as
+      // viewSize. The delete action therefore carries only the list filters,
+      // while the cancel link re-appends view so the restored card renders at
+      // the size the user was looking at.
+      svc.getPin.mockResolvedValue(makePin())
+
+      const html = await (
+        await app.request('/pins/pin-1/delete-confirm?view=compact&tag=foo')
+      ).text()
+
+      expect(html).toContain('hx-delete="/pins/pin-1?tag=foo"')
+      expect(html).toContain('/pins/pin-1/card?tag=foo&amp;view=compact')
+    })
+
+    it('404s for a missing pin', async () => {
+      svc.getPin.mockRejectedValue(new PinNotFoundError('pin-1'))
+
+      const res = await app.request('/pins/pin-1/delete-confirm')
+
+      expect(res.status).toBe(404)
+    })
+
+    it('404s rather than 403 when the pin belongs to someone else', async () => {
+      svc.getPin.mockRejectedValue(new UnauthorizedPinAccessError('pin-1'))
+
+      const res = await app.request('/pins/pin-1/delete-confirm')
+
+      expect(res.status).toBe(404)
+    })
+  })
+
+  describe('DELETE /:id', () => {
+    it('deletes the pin and returns the refreshed list partial', async () => {
+      svc.deletePin.mockResolvedValue(true)
+
+      const res = await app.request('/pins/pin-1', { method: 'DELETE' })
+
+      expect(svc.deletePin).toHaveBeenCalledWith(expect.anything(), 'pin-1')
+      expect(res.status).toBe(200)
+
+      const html = await res.text()
+      expect(html).toContain('Example Pin')
+      expect(html).not.toContain('<html')
+    })
+
+    it('re-applies the current filters when rebuilding the list', async () => {
+      svc.deletePin.mockResolvedValue(true)
+
+      await app.request('/pins/pin-1?tag=foo&unread=true', {
+        method: 'DELETE',
+      })
+
+      expect(svc.getUserPinsWithPagination.mock.calls[0][1]).toMatchObject({
+        isPrivate: false,
+        tag: 'foo',
+        readLater: true,
+      })
+    })
+  })
+
+  describe('GET|POST /:id/delete — full-page delete', () => {
+    it('renders the confirmation page', async () => {
+      svc.getPin.mockResolvedValue(makePin())
+
+      const res = await app.request('/pins/pin-1/delete')
+
+      expect(res.status).toBe(200)
+      expect(await res.text()).toContain('Example Pin')
+    })
+
+    it('deletes and redirects to the list on POST', async () => {
+      svc.getPin.mockResolvedValue(makePin())
+      svc.deletePin.mockResolvedValue(true)
+
+      const res = await app.request('/pins/pin-1/delete', { method: 'POST' })
+
+      expect(svc.deletePin).toHaveBeenCalledWith(expect.anything(), 'pin-1')
+      expect(res.status).toBe(302)
+      expect(res.headers.get('Location')).toBe('/pins')
+    })
+  })
+
+  describe('GET /:id/card', () => {
+    it('returns a bare card fragment', async () => {
+      svc.getPin.mockResolvedValue(makePin())
+
+      const res = await app.request('/pins/pin-1/card')
+      const html = await res.text()
+
+      expect(res.status).toBe(200)
+      expect(html).toContain('Example Pin')
+      expect(html).not.toContain('<html')
+    })
+  })
+
+  describe('base URL wiring', () => {
+    it('renders card links against /pins', async () => {
+      svc.getPin.mockResolvedValue(makePin())
+
+      const html = await (await app.request('/pins/pin-1/card')).text()
+
+      expect(html).toContain('/pins/pin-1')
+      expect(html).not.toContain('/private/pins/pin-1')
+    })
+  })
+})

--- a/apps/hono/src/routes/private.test.tsx
+++ b/apps/hono/src/routes/private.test.tsx
@@ -1,0 +1,477 @@
+/**
+ * Characterization tests for the private pin routes.
+ *
+ * Deliberately mirrors `pins.test.tsx` section for section: the two route files
+ * share 558 identical lines, so the suites should read the same too. Where this
+ * file asserts something `pins.test.tsx` does not — or asserts it differently —
+ * that is a genuine behavioral divergence between the two routers, and each one
+ * is called out inline. Those are the cases a shared route factory has to keep.
+ *
+ * `requirePrivateUnlock` is exercised for real rather than stubbed, since the
+ * unlock gate is the one piece of behavior with no counterpart in `pins.tsx`.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+import type { MiddlewareHandler } from 'hono'
+import {
+  Pagination,
+  DuplicatePinError,
+  InvalidCredentialsError,
+  PinNotFoundError,
+} from '@pinsquirrel/domain'
+import {
+  testUser,
+  makePin,
+  makeTag,
+  createServiceMocks,
+  createSessionMocks,
+  fakeSessionManager,
+  formBody,
+} from '../test-support/pin-routes'
+
+const svc = createServiceMocks()
+const session = createSessionMocks()
+
+vi.mock('../lib/services', () => ({
+  authService: {
+    login: (...a: unknown[]) => svc.login(...a) as unknown,
+  },
+  pinService: {
+    getPin: (...a: unknown[]) => svc.getPin(...a) as unknown,
+    createPin: (...a: unknown[]) => svc.createPin(...a) as unknown,
+    updatePin: (...a: unknown[]) => svc.updatePin(...a) as unknown,
+    deletePin: (...a: unknown[]) => svc.deletePin(...a) as unknown,
+    getUserPinsWithPagination: (...a: unknown[]) =>
+      svc.getUserPinsWithPagination(...a) as unknown,
+  },
+  tagService: {
+    getUserTags: (...a: unknown[]) => svc.getUserTags(...a) as unknown,
+  },
+}))
+
+vi.mock('../middleware/session', () => ({
+  requireAuth: (): MiddlewareHandler => async (_c, next) => {
+    await next()
+  },
+  getSessionManager: () => fakeSessionManager(session),
+}))
+
+import { privateRoutes } from './private'
+
+describe('private routes', () => {
+  let app: Hono
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    session.getUser.mockResolvedValue(testUser)
+    session.getFlash.mockReturnValue(null)
+    session.isPrivateUnlocked.mockReturnValue(true)
+    svc.getUserTags.mockResolvedValue([makeTag()])
+    svc.getUserPinsWithPagination.mockResolvedValue({
+      pins: [makePin({ isPrivate: true })],
+      pagination: Pagination.fromTotalCount(1),
+    })
+    app = new Hono()
+    app.route('/private', privateRoutes)
+  })
+
+  // ---- No counterpart in pins.tsx -----------------------------------------
+
+  describe('unlock gate', () => {
+    it('redirects pin routes to /private/unlock while locked', async () => {
+      session.isPrivateUnlocked.mockReturnValue(false)
+
+      const res = await app.request('/private/pins')
+
+      expect(res.status).toBe(302)
+      expect(res.headers.get('Location')).toBe('/private/unlock')
+      expect(svc.getUserPinsWithPagination).not.toHaveBeenCalled()
+    })
+
+    // Sub-routes need their own assertions, not just the list. Verified by
+    // mutation: deleting `use('/pins/*', requirePrivateUnlock())` while only
+    // the list was covered went undetected — every pin detail route would have
+    // been reachable while locked, with a green suite.
+    //
+    // (The companion `use('/pins', ...)` registration is redundant on Hono
+    // 4.13 — a `/pins/*` middleware already runs for a bare `/pins` request,
+    // confirmed by probe. Harmless, but not load-bearing.)
+    it.each([
+      ['/private/pins/new', 'GET'],
+      ['/private/pins/pin-1/edit', 'GET'],
+      ['/private/pins/pin-1/card', 'GET'],
+      ['/private/pins/pin-1/delete', 'GET'],
+    ])('gates %s while locked', async (path) => {
+      session.isPrivateUnlocked.mockReturnValue(false)
+
+      const res = await app.request(path)
+
+      expect(res.status).toBe(302)
+      expect(res.headers.get('Location')).toBe('/private/unlock')
+      expect(svc.getPin).not.toHaveBeenCalled()
+      expect(svc.getUserTags).not.toHaveBeenCalled()
+    })
+
+    it('gates mutating sub-routes while locked', async () => {
+      session.isPrivateUnlocked.mockReturnValue(false)
+
+      const created = await app.request(
+        '/private/pins/new',
+        formBody({ url: 'https://x.test/a', title: 'T' })
+      )
+      const deleted = await app.request('/private/pins/pin-1', {
+        method: 'DELETE',
+      })
+
+      expect(created.status).toBe(302)
+      expect(deleted.status).toBe(302)
+      expect(svc.createPin).not.toHaveBeenCalled()
+      expect(svc.deletePin).not.toHaveBeenCalled()
+    })
+
+    it('uses HX-Redirect for HTMX requests while locked', async () => {
+      session.isPrivateUnlocked.mockReturnValue(false)
+
+      const res = await app.request('/private/pins', {
+        headers: { 'HX-Request': 'true' },
+      })
+
+      expect(res.status).toBe(200)
+      expect(res.headers.get('HX-Redirect')).toBe('/private/unlock')
+    })
+
+    it('renders the unlock form when locked', async () => {
+      session.isPrivateUnlocked.mockReturnValue(false)
+
+      const res = await app.request('/private/unlock')
+
+      expect(res.status).toBe(200)
+      expect(await res.text()).toContain('password')
+    })
+
+    it('skips the unlock form when already unlocked', async () => {
+      const res = await app.request('/private/unlock')
+
+      expect(res.status).toBe(302)
+      expect(res.headers.get('Location')).toBe('/private/pins')
+    })
+
+    it('unlocks on a correct password', async () => {
+      svc.login.mockResolvedValue(testUser)
+
+      const res = await app.request(
+        '/private/unlock',
+        formBody({ password: 'correct-horse' })
+      )
+
+      expect(svc.login).toHaveBeenCalledWith({
+        username: testUser.username,
+        password: 'correct-horse',
+      })
+      expect(session.unlockPrivateMode).toHaveBeenCalled()
+      expect(res.headers.get('Location')).toBe('/private/pins')
+    })
+
+    it('re-renders with an error on a wrong password, without unlocking', async () => {
+      svc.login.mockRejectedValue(new InvalidCredentialsError())
+
+      const res = await app.request(
+        '/private/unlock',
+        formBody({ password: 'wrong' })
+      )
+
+      expect(res.status).toBe(200)
+      expect(await res.text()).toContain('Invalid password')
+      expect(session.unlockPrivateMode).not.toHaveBeenCalled()
+    })
+
+    it('locks and redirects to the public list', async () => {
+      const res = await app.request('/private/lock', { method: 'POST' })
+
+      expect(session.lockPrivateMode).toHaveBeenCalled()
+      expect(res.headers.get('Location')).toBe('/pins')
+    })
+
+    it('returns 204 for a text/plain beacon on lock (tab close)', async () => {
+      const res = await app.request('/private/lock', {
+        method: 'POST',
+        headers: { 'Content-Type': 'text/plain' },
+      })
+
+      expect(res.status).toBe(204)
+      expect(session.lockPrivateMode).toHaveBeenCalled()
+    })
+  })
+
+  // ---- Mirrors pins.test.tsx ----------------------------------------------
+
+  describe('GET /pins — list', () => {
+    it('forces the filter to private pins', async () => {
+      const res = await app.request('/private/pins')
+
+      expect(res.status).toBe(200)
+      expect(svc.getUserPinsWithPagination.mock.calls[0][1]).toMatchObject({
+        isPrivate: true,
+      })
+    })
+
+    it('uses a fixed page size of 25, as the public list does', async () => {
+      await app.request('/private/pins')
+
+      expect(svc.getUserPinsWithPagination.mock.calls[0][2]).toEqual({
+        page: 1,
+        pageSize: 25,
+      })
+    })
+
+    it('maps query params onto the filter, as the public list does', async () => {
+      await app.request('/private/pins?tag=foo&search=box&notags=true&page=3')
+
+      const [, filter, options] = svc.getUserPinsWithPagination.mock.calls[0]
+      expect(filter).toMatchObject({
+        isPrivate: true,
+        tag: 'foo',
+        search: 'box',
+        noTags: true,
+      })
+      expect(options).toMatchObject({ page: 3 })
+    })
+
+    it('returns only the content partial for HTMX requests', async () => {
+      const full = await app.request('/private/pins')
+      const partial = await app.request('/private/pins', {
+        headers: { 'HX-Request': 'true' },
+      })
+
+      expect(partial.status).toBe(200)
+      expect((await partial.text()).length).toBeLessThan(
+        (await full.text()).length
+      )
+    })
+  })
+
+  describe('GET /pins/new — create form', () => {
+    it('renders the form', async () => {
+      const res = await app.request('/private/pins/new')
+
+      expect(res.status).toBe(200)
+    })
+
+    // DIVERGENCE: the public GET /pins/new looks the prefill URL up and
+    // redirects to the existing pin's edit page (bookmarklet dedup). The
+    // private form has no such lookup, so a duplicate URL is only caught on
+    // submit. A shared factory must keep this optional, not unify it.
+    it('does NOT perform the bookmarklet dedup lookup', async () => {
+      await app.request('/private/pins/new?url=https%3A%2F%2Fx.test%2Fa')
+
+      expect(svc.getUserPinsWithPagination).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('POST /pins/new — create', () => {
+    it('creates a pin and redirects to the private list', async () => {
+      svc.createPin.mockResolvedValue(makePin({ isPrivate: true }))
+
+      const res = await app.request(
+        '/private/pins/new',
+        formBody({ url: 'https://x.test/a', title: 'Hello', tags: 'foo, bar' })
+      )
+
+      expect(res.status).toBe(302)
+      expect(res.headers.get('Location')).toBe('/private/pins')
+      expect(svc.createPin).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          userId: testUser.id,
+          url: 'https://x.test/a',
+          title: 'Hello',
+          tagNames: ['foo', 'bar'],
+        })
+      )
+    })
+
+    // DIVERGENCE (create): isPrivate is hardcoded true and the submitted form
+    // value is ignored. Compare the edit handler below, which honours it.
+    it('forces isPrivate true, ignoring the submitted value', async () => {
+      svc.createPin.mockResolvedValue(makePin({ isPrivate: true }))
+
+      await app.request(
+        '/private/pins/new',
+        formBody({ url: 'https://x.test/a', title: 'T', isPrivate: 'false' })
+      )
+
+      expect(svc.createPin.mock.calls[0][1]).toMatchObject({ isPrivate: true })
+    })
+
+    it('re-renders the form without redirecting on a duplicate URL', async () => {
+      svc.createPin.mockRejectedValue(new DuplicatePinError('https://x.test/a'))
+
+      const res = await app.request(
+        '/private/pins/new',
+        formBody({ url: 'https://x.test/a', title: 'T' })
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.headers.get('Location')).toBeNull()
+    })
+
+    it('uses HX-Redirect instead of a 302 for HTMX submissions', async () => {
+      svc.createPin.mockResolvedValue(makePin())
+
+      const res = await app.request('/private/pins/new', {
+        ...formBody({ url: 'https://x.test/a', title: 'T' }),
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'HX-Request': 'true',
+        },
+      })
+
+      expect(res.headers.get('HX-Redirect')).toBe('/private/pins')
+    })
+  })
+
+  describe('POST /pins/:id/edit — update', () => {
+    beforeEach(() => {
+      svc.getPin.mockResolvedValue(makePin({ isPrivate: true }))
+      svc.updatePin.mockResolvedValue(makePin({ isPrivate: true }))
+    })
+
+    it('updates and redirects to the private list', async () => {
+      const res = await app.request(
+        '/private/pins/pin-1/edit',
+        formBody({ url: 'https://x.test/b', title: 'Updated' })
+      )
+
+      expect(res.status).toBe(302)
+      expect(res.headers.get('Location')).toBe('/private/pins')
+      expect(svc.updatePin).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ id: 'pin-1', title: 'Updated' })
+      )
+    })
+
+    // DIVERGENCE (edit): unlike create above, the edit handler reads isPrivate
+    // from the form — so a pin can be made public from inside the private view.
+    // Asymmetric with create by design or by accident; pinned here either way.
+    it('honours the submitted isPrivate, allowing a pin to be made public', async () => {
+      await app.request(
+        '/private/pins/pin-1/edit',
+        formBody({ url: 'https://x.test/b', title: 'T', isPrivate: 'false' })
+      )
+
+      expect(svc.updatePin.mock.calls[0][1]).toMatchObject({
+        isPrivate: false,
+      })
+    })
+
+    it('preserves list filters in the redirect target', async () => {
+      const res = await app.request(
+        '/private/pins/pin-1/edit?tag=foo&page=2',
+        formBody({ url: 'https://x.test/b', title: 'Updated' })
+      )
+
+      expect(res.headers.get('Location')).toBe('/private/pins?tag=foo&page=2')
+    })
+  })
+
+  describe('POST /pins/:id/toggle-read', () => {
+    it('flips readLater and returns just the card', async () => {
+      svc.getPin.mockResolvedValue(makePin({ readLater: false }))
+      svc.updatePin.mockResolvedValue(makePin({ readLater: true }))
+
+      const res = await app.request('/private/pins/pin-1/toggle-read', {
+        method: 'POST',
+      })
+
+      expect(res.status).toBe(200)
+      expect(svc.updatePin.mock.calls[0][1]).toMatchObject({ readLater: true })
+      expect(await res.text()).not.toContain('<html')
+    })
+
+    it('preserves the pin’s existing isPrivate when toggling', async () => {
+      svc.getPin.mockResolvedValue(makePin({ isPrivate: true }))
+      svc.updatePin.mockResolvedValue(makePin({ isPrivate: true }))
+
+      await app.request('/private/pins/pin-1/toggle-read', { method: 'POST' })
+
+      expect(svc.updatePin.mock.calls[0][1]).toMatchObject({ isPrivate: true })
+    })
+  })
+
+  describe('GET /pins/:id/delete-confirm — inline confirmation', () => {
+    it('returns the confirmation fragment against the private base URL', async () => {
+      svc.getPin.mockResolvedValue(makePin({ isPrivate: true }))
+
+      const html = await (
+        await app.request('/private/pins/pin-1/delete-confirm')
+      ).text()
+
+      expect(html).toContain('/private/pins/pin-1')
+      expect(html).not.toContain('<html')
+    })
+
+    it('404s for a missing pin', async () => {
+      svc.getPin.mockRejectedValue(new PinNotFoundError('pin-1'))
+
+      const res = await app.request('/private/pins/pin-1/delete-confirm')
+
+      expect(res.status).toBe(404)
+    })
+  })
+
+  describe('DELETE /pins/:id', () => {
+    it('deletes the pin and returns the refreshed list partial', async () => {
+      svc.deletePin.mockResolvedValue(true)
+
+      const res = await app.request('/private/pins/pin-1', { method: 'DELETE' })
+
+      expect(svc.deletePin).toHaveBeenCalledWith(expect.anything(), 'pin-1')
+      expect(res.status).toBe(200)
+      expect(await res.text()).not.toContain('<html')
+    })
+
+    it('keeps the list private when rebuilding after delete', async () => {
+      svc.deletePin.mockResolvedValue(true)
+
+      await app.request('/private/pins/pin-1?tag=foo', { method: 'DELETE' })
+
+      expect(svc.getUserPinsWithPagination.mock.calls[0][1]).toMatchObject({
+        isPrivate: true,
+        tag: 'foo',
+      })
+    })
+  })
+
+  describe('GET|POST /pins/:id/delete — full-page delete', () => {
+    it('renders the confirmation page', async () => {
+      svc.getPin.mockResolvedValue(makePin({ isPrivate: true }))
+
+      const res = await app.request('/private/pins/pin-1/delete')
+
+      expect(res.status).toBe(200)
+    })
+
+    it('deletes and redirects to the private list on POST', async () => {
+      svc.getPin.mockResolvedValue(makePin({ isPrivate: true }))
+      svc.deletePin.mockResolvedValue(true)
+
+      const res = await app.request('/private/pins/pin-1/delete', {
+        method: 'POST',
+      })
+
+      expect(svc.deletePin).toHaveBeenCalledWith(expect.anything(), 'pin-1')
+      expect(res.status).toBe(302)
+      expect(res.headers.get('Location')).toBe('/private/pins')
+    })
+  })
+
+  describe('base URL wiring', () => {
+    it('renders card links against /private/pins, not /pins', async () => {
+      svc.getPin.mockResolvedValue(makePin())
+
+      const html = await (await app.request('/private/pins/pin-1/card')).text()
+
+      expect(html).toContain('/private/pins/pin-1')
+    })
+  })
+})

--- a/apps/hono/src/test-support/pin-routes.tsx
+++ b/apps/hono/src/test-support/pin-routes.tsx
@@ -1,0 +1,122 @@
+/**
+ * Shared fixtures for the pin route characterization tests.
+ *
+ * `pins.tsx` and `private.tsx` are near-identical today, so their tests need
+ * the same fakes. Keeping them here means the suites can be compared directly —
+ * a behavior only one of them asserts is a real divergence, not a difference in
+ * test setup.
+ */
+import { vi } from 'vitest'
+import type { Mock } from 'vitest'
+import type { Pin, Tag, User } from '@pinsquirrel/domain'
+
+export const testUser = {
+  id: 'user-1',
+  username: 'alice',
+  email: 'alice@example.com',
+} as unknown as User
+
+export function makePin(overrides: Partial<Pin> = {}): Pin {
+  return {
+    id: 'pin-1',
+    userId: 'user-1',
+    url: 'https://example.com',
+    title: 'Example Pin',
+    description: null,
+    readLater: false,
+    isPrivate: false,
+    tagNames: [],
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+    ...overrides,
+  }
+}
+
+export function makeTag(overrides: Partial<Tag> = {}): Tag {
+  return {
+    id: 'tag-1',
+    userId: 'user-1',
+    name: 'foo',
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+    ...overrides,
+  }
+}
+
+/** Mock fns for `../lib/services`, shared by both route suites. */
+export interface ServiceMocks {
+  getPin: Mock
+  createPin: Mock
+  updatePin: Mock
+  deletePin: Mock
+  getUserPinsWithPagination: Mock
+  getUserTags: Mock
+  login: Mock
+}
+
+export function createServiceMocks(): ServiceMocks {
+  return {
+    getPin: vi.fn(),
+    createPin: vi.fn(),
+    updatePin: vi.fn(),
+    deletePin: vi.fn(),
+    getUserPinsWithPagination: vi.fn(),
+    getUserTags: vi.fn(),
+    login: vi.fn(),
+  }
+}
+
+/** Mock fns backing the fake `SessionManager`. */
+export interface SessionMocks {
+  getUser: Mock
+  setFlash: Mock
+  getFlash: Mock
+  isPrivateUnlocked: Mock
+  unlockPrivateMode: Mock
+  lockPrivateMode: Mock
+}
+
+export function createSessionMocks(): SessionMocks {
+  return {
+    getUser: vi.fn(),
+    setFlash: vi.fn(),
+    getFlash: vi.fn(),
+    isPrivateUnlocked: vi.fn(),
+    unlockPrivateMode: vi.fn(),
+    lockPrivateMode: vi.fn(),
+  }
+}
+
+/**
+ * A fake SessionManager covering the whole interface. Routes reach for
+ * `getFlash()` during render, so a partial fake fails at render time rather
+ * than at the assertion.
+ */
+export function fakeSessionManager(mocks: SessionMocks) {
+  return {
+    getSession: () => null,
+    getData: () => null,
+    getUserId: () => testUser.id,
+    isAuthenticated: () => true,
+    create: () => Promise.resolve(),
+    destroy: () => Promise.resolve(),
+    getUser: (...a: unknown[]) => mocks.getUser(...a) as unknown,
+    setFlash: (...a: unknown[]) => mocks.setFlash(...a) as unknown,
+    getFlash: (...a: unknown[]) => mocks.getFlash(...a) as unknown,
+    isPrivateUnlocked: (...a: unknown[]) =>
+      mocks.isPrivateUnlocked(...a) as unknown,
+    unlockPrivateMode: (...a: unknown[]) =>
+      mocks.unlockPrivateMode(...a) as unknown,
+    lockPrivateMode: (...a: unknown[]) =>
+      mocks.lockPrivateMode(...a) as unknown,
+  }
+}
+
+/** Encode a record as an HTML form body, the way the routes receive it. */
+export function formBody(fields: Record<string, string>): RequestInit {
+  return {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams(fields).toString(),
+  }
+}

--- a/package.json
+++ b/package.json
@@ -41,14 +41,14 @@
     "tsx": "^4.23.12"
   },
   "lint-staged": {
-    "apps/hono/src/**/*.{ts,tsx}": "pnpm --filter @pinsquirrel/hono eslint --fix",
-    "apps/admin/src/**/*.{ts,tsx}": "pnpm --filter @pinsquirrel/admin eslint --fix",
-    "libs/services/**/*.{ts,tsx,js,jsx}": "pnpm --filter @pinsquirrel/services eslint --fix",
-    "libs/database/**/*.{ts,tsx,js,jsx}": "pnpm --filter @pinsquirrel/database eslint --fix",
-    "libs/domain/**/*.{ts,tsx,js,jsx}": "pnpm --filter @pinsquirrel/domain eslint --fix",
-    "libs/crypto/**/*.{ts,tsx}": "pnpm --filter @pinsquirrel/crypto eslint --fix",
-    "libs/adapters/**/*.{ts,tsx,js,jsx}": "pnpm --filter @pinsquirrel/adapters eslint --fix",
-    "libs/mailgun/**/*.{ts,tsx,js,jsx}": "pnpm --filter @pinsquirrel/mailgun eslint --fix",
+    "apps/hono/src/**/*.{ts,tsx}": "pnpm --filter @pinsquirrel/hono exec eslint --fix",
+    "apps/admin/src/**/*.{ts,tsx}": "pnpm --filter @pinsquirrel/admin exec eslint --fix",
+    "libs/services/**/*.{ts,tsx,js,jsx}": "pnpm --filter @pinsquirrel/services exec eslint --fix",
+    "libs/database/**/*.{ts,tsx,js,jsx}": "pnpm --filter @pinsquirrel/database exec eslint --fix",
+    "libs/domain/**/*.{ts,tsx,js,jsx}": "pnpm --filter @pinsquirrel/domain exec eslint --fix",
+    "libs/crypto/**/*.{ts,tsx}": "pnpm --filter @pinsquirrel/crypto exec eslint --fix",
+    "libs/adapters/**/*.{ts,tsx,js,jsx}": "pnpm --filter @pinsquirrel/adapters exec eslint --fix",
+    "libs/mailgun/**/*.{ts,tsx,js,jsx}": "pnpm --filter @pinsquirrel/mailgun exec eslint --fix",
     "**/*.{ts,tsx,js,jsx,json,md,css}": "prettier --write"
   }
 }


### PR DESCRIPTION
Step 1 of the simplification plan: a safety net before touching `pins.tsx` / `private.tsx`.

Two commits — a blocking hook fix, then the tests.

## Why this first

`pins.tsx` (810 lines) and `private.tsx` (763) share **558 identical lines**, and had **zero** test coverage. Route tests existed only for `api-v1`, `seo`, `health`, and the markdown pages — 4 test files for 15 route files. Collapsing them behind a shared factory is the largest simplification available in this codebase, and it isn't safe to attempt blind.

**70 tests**, asserting what the code does *today*, not what it ought to. Where behavior looks questionable it's captured and labelled, so the refactor stays provably behavior-preserving.

## Three divergences pinned

The suites mirror each other section for section, so a behavior only one asserts is a real divergence rather than a difference in test setup. Reading the two files surfaced three; all three are now tests with explanatory comments:

| Divergence | Behavior |
|---|---|
| **create vs edit** | private *create* hardcodes `isPrivate: true` and ignores the submitted form value; private *edit* honours it — so a pin can be made public from inside the private view |
| **bookmarklet dedup** | public `GET /new` redirects to an existing pin when the prefill URL is already saved; the private form has no such lookup, so duplicates are only caught on submit |

The create/edit asymmetry may well be intentional. It's undocumented either way, and it's exactly what gets lost when two files are maintained by copy-paste. A factory forces it to become an explicit parameter.

## Validated by mutation, not by a green run

A characterization test that passes proves nothing until you show it fails when behavior changes. I injected **13 deliberate behavior changes** — flipping the `isPrivate` filter, changing page size, dropping tag trimming, swallowing `DuplicatePinError`, redirecting lock to the wrong list, and so on. **All 13 caught.**

One escaped initially, and it's the reason this step mattered:

> Deleting `use('/pins/*', requirePrivateUnlock())` went **undetected**, because only the list route was covered. Every private pin *detail* route would have been reachable while locked — with a fully green suite.

Sub-route gate assertions now close that hole; re-running the same mutation fails 5 tests.

## Coverage

| File | Lines | Functions |
|---|---|---|
| `pins.tsx` | 0% → **77%** | **96%** |
| `private.tsx` | 0% → **70%** | **88%** |

Function coverage is the number that matters here — nearly every handler the factory will produce is now exercised.

## Commit 1 — a pre-existing hook bug that blocks all TypeScript commits

Committing the tests failed, which exposed this. Every per-workspace lint-staged rule invoked:

```
pnpm --filter <pkg> eslint --fix
```

pnpm reads that as *"run the package's `eslint` **script**"*. No workspace defines one — they define `lint`. So all eight rules failed with `ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT`, aborting the pre-commit hook for **any** `.ts`/`.tsx` file in **any** workspace. Only the catch-all prettier rule ever ran; eslint has never actually gated a commit here.

Fix is `pnpm --filter <pkg> exec eslint --fix` — run the binary rather than look for a script.

Pre-existing on `main`, and unrelated to #81 (which changed how lint-staged is *invoked*, not what it invokes). It surfaced now only because every commit since then touched `.md`/`.yaml`/`.json` exclusively.

## Incidental finding — noted, not acted on

`private.tsx:90`'s `use('/pins', requirePrivateUnlock())` is redundant on Hono 4.13: a `/pins/*` middleware already runs for a bare `/pins` request. Confirmed with a standalone probe rather than inferred. Harmless but not load-bearing — left alone since this PR is tests-only.

## Verification

- `pnpm quality` green; full hono suite 154 passed
- No production code modified — every mutation was reverted and the working tree confirmed clean

## Next

With the net in place: `requireAuth` sets the user on context (~144 lines), extract `getString` (6 duplicate definitions), then the `createPinRoutes` factory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added comprehensive coverage for public and private pin routes, including listing, filtering, sorting, creation, editing, deletion, read-state changes, validation, pagination, and HTMX responses.
  - Added tests for private pin locking and unlocking behavior.
  - Added shared test fixtures and helpers for consistent route testing.
- **Chores**
  - Improved staged linting across package contexts and expanded JavaScript/JSX coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->