### PR TITLE
refactor: extract the form-reading helpers into lib/form

### DIFF
--- a/apps/hono/src/lib/form.test.ts
+++ b/apps/hono/src/lib/form.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest'
+import { getString, parseTagNames, parsePinForm } from './form'
+
+describe('getString', () => {
+  it('returns strings unchanged', () => {
+    expect(getString('hello')).toBe('hello')
+    expect(getString('')).toBe('')
+  })
+
+  it('takes the first entry of a repeated field', () => {
+    expect(getString(['a', 'b'])).toBe('a')
+  })
+
+  it('recurses into nested arrays', () => {
+    expect(getString([['a']])).toBe('a')
+  })
+
+  it('returns empty string for a missing or non-string field', () => {
+    expect(getString(undefined)).toBe('')
+    expect(getString(null)).toBe('')
+    expect(getString(42)).toBe('')
+    expect(getString([])).toBe('')
+    // parseBody yields File objects for uploads; treat them as absent rather
+    // than stringifying them into "[object File]".
+    expect(getString(new File([], 'x.txt'))).toBe('')
+  })
+})
+
+describe('parseTagNames', () => {
+  it('splits on commas and trims', () => {
+    expect(parseTagNames('foo, bar')).toEqual(['foo', 'bar'])
+    expect(parseTagNames(' foo , bar ')).toEqual(['foo', 'bar'])
+  })
+
+  it('drops empty entries', () => {
+    expect(parseTagNames(' foo , , bar ')).toEqual(['foo', 'bar'])
+    expect(parseTagNames('')).toEqual([])
+    expect(parseTagNames(',,')).toEqual([])
+  })
+
+  it('keeps a single tag', () => {
+    expect(parseTagNames('foo')).toEqual(['foo'])
+  })
+})
+
+describe('parsePinForm', () => {
+  it('reads every pin field', () => {
+    expect(
+      parsePinForm({
+        url: 'https://x.test/a',
+        title: 'Title',
+        description: 'Desc',
+        readLater: 'true',
+        isPrivate: 'true',
+        tags: 'foo, bar',
+      })
+    ).toEqual({
+      url: 'https://x.test/a',
+      title: 'Title',
+      description: 'Desc',
+      readLater: true,
+      isPrivate: true,
+      tagsInput: 'foo, bar',
+      tagNames: ['foo', 'bar'],
+    })
+  })
+
+  it('maps an empty description to null, not empty string', () => {
+    expect(parsePinForm({ description: '' }).description).toBeNull()
+    expect(parsePinForm({}).description).toBeNull()
+  })
+
+  it('treats the booleans as true only for the literal string "true"', () => {
+    expect(parsePinForm({ readLater: 'on' }).readLater).toBe(false)
+    expect(parsePinForm({ readLater: 'TRUE' }).readLater).toBe(false)
+    expect(parsePinForm({ isPrivate: '1' }).isPrivate).toBe(false)
+    expect(parsePinForm({ readLater: 'true' }).readLater).toBe(true)
+  })
+
+  it('defaults an empty form to blank values rather than throwing', () => {
+    expect(parsePinForm({})).toEqual({
+      url: '',
+      title: '',
+      description: null,
+      readLater: false,
+      isPrivate: false,
+      tagsInput: '',
+      tagNames: [],
+    })
+  })
+})

--- a/apps/hono/src/lib/form.ts
+++ b/apps/hono/src/lib/form.ts
@@ -1,0 +1,67 @@
+/**
+ * Helpers for reading Hono's `parseBody()` output.
+ *
+ * `parseBody()` returns `string | File | (string | File)[]` per field: a repeated
+ * input yields an array, a file input yields a File, and an absent field yields
+ * undefined. Handlers want a plain string, so every one of them used to declare
+ * its own coercion inline.
+ */
+
+/** Anything `c.req.parseBody()` can produce for a single field. */
+export type FormValue = unknown
+
+/** A parsed form body, as returned by `c.req.parseBody()`. */
+export type FormBody = Record<string, FormValue>
+
+/**
+ * Coerce one parsed form field to a string.
+ *
+ * Repeated fields collapse to their first entry; files, numbers, and missing
+ * fields become `''` rather than being stringified.
+ */
+export function getString(value: FormValue): string {
+  if (typeof value === 'string') return value
+  if (Array.isArray(value)) return getString(value[0])
+  return ''
+}
+
+/** Split a comma-separated tag input, trimming blanks. */
+export function parseTagNames(input: string): string[] {
+  return input
+    .split(',')
+    .map((tag) => tag.trim())
+    .filter((tag) => tag.length > 0)
+}
+
+export interface PinFormFields {
+  url: string
+  title: string
+  /** `null` rather than `''` so it maps straight onto the nullable column. */
+  description: string | null
+  readLater: boolean
+  isPrivate: boolean
+  /** The raw input, kept for re-rendering the form after a failed submit. */
+  tagsInput: string
+  tagNames: string[]
+}
+
+/**
+ * Read the pin create/edit form.
+ *
+ * `isPrivate` is reported as submitted. Routes that force it — the private
+ * create form always stores a private pin — override it at the call site, so
+ * that decision stays visible where it is made rather than hidden in here.
+ */
+export function parsePinForm(formData: FormBody): PinFormFields {
+  const tagsInput = getString(formData.tags)
+
+  return {
+    url: getString(formData.url),
+    title: getString(formData.title),
+    description: getString(formData.description) || null,
+    readLater: getString(formData.readLater) === 'true',
+    isPrivate: getString(formData.isPrivate) === 'true',
+    tagsInput,
+    tagNames: parseTagNames(tagsInput),
+  }
+}

--- a/apps/hono/src/routes/pins.test.tsx
+++ b/apps/hono/src/routes/pins.test.tsx
@@ -252,6 +252,20 @@ describe('pins routes', () => {
       expect(svc.createPin.mock.calls[0][1]).toMatchObject({ readLater: false })
     })
 
+    it('sends null, not empty string, for an omitted description', async () => {
+      // Reaches the database as a nullable column, so the distinction matters.
+      svc.createPin.mockResolvedValue(makePin())
+
+      await app.request(
+        '/pins/new',
+        formBody({ url: 'https://x.test/a', title: 'T', description: '' })
+      )
+
+      expect(svc.createPin.mock.calls[0][1]).toMatchObject({
+        description: null,
+      })
+    })
+
     it('drops empty tags and trims whitespace', async () => {
       svc.createPin.mockResolvedValue(makePin())
 

--- a/apps/hono/src/routes/pins.tsx
+++ b/apps/hono/src/routes/pins.tsx
@@ -10,6 +10,7 @@ import {
   UnauthorizedPinAccessError,
 } from '@pinsquirrel/domain'
 import { pinService, tagService } from '../lib/services'
+import { parsePinForm } from '../lib/form'
 import {
   getAuthUser,
   getSessionManager,
@@ -230,25 +231,15 @@ pins.post('/new', async (c) => {
   // Parse form data
   const formData = await c.req.parseBody()
 
-  // Helper to safely extract string from form data (handles File | string | array)
-  const getString = (value: unknown): string => {
-    if (typeof value === 'string') return value
-    if (Array.isArray(value)) return getString(value[0])
-    return ''
-  }
-
-  const pinUrl = getString(formData.url)
-  const title = getString(formData.title)
-  const description = getString(formData.description) || null
-  const readLater = getString(formData.readLater) === 'true'
-  const isPrivate = getString(formData.isPrivate) === 'true'
-  const tagsInput = getString(formData.tags)
-
-  // Parse tags from comma-separated string
-  const tagNames = tagsInput
-    .split(',')
-    .map((t) => t.trim())
-    .filter((t) => t.length > 0)
+  const {
+    url: pinUrl,
+    title,
+    description,
+    readLater,
+    isPrivate,
+    tagsInput,
+    tagNames,
+  } = parsePinForm(formData)
 
   // Fetch user's tags for re-rendering form on error
   const userTags = await tagService.getUserTags(ac, user.id)
@@ -405,24 +396,15 @@ pins.post('/:id/edit', async (c) => {
   const formData = await c.req.parseBody()
 
   // Helper to safely extract string from form data
-  const getString = (value: unknown): string => {
-    if (typeof value === 'string') return value
-    if (Array.isArray(value)) return getString(value[0])
-    return ''
-  }
-
-  const pinUrl = getString(formData.url)
-  const title = getString(formData.title)
-  const description = getString(formData.description) || null
-  const readLater = getString(formData.readLater) === 'true'
-  const isPrivate = getString(formData.isPrivate) === 'true'
-  const tagsInput = getString(formData.tags)
-
-  // Parse tags from comma-separated string
-  const tagNames = tagsInput
-    .split(',')
-    .map((t) => t.trim())
-    .filter((t) => t.length > 0)
+  const {
+    url: pinUrl,
+    title,
+    description,
+    readLater,
+    isPrivate,
+    tagsInput,
+    tagNames,
+  } = parsePinForm(formData)
 
   // Fetch user's tags for re-rendering form on error
   const userTags = await tagService.getUserTags(ac, user.id)

--- a/apps/hono/src/routes/private.tsx
+++ b/apps/hono/src/routes/private.tsx
@@ -8,6 +8,7 @@ import {
   InvalidCredentialsError,
 } from '@pinsquirrel/domain'
 import { authService, pinService, tagService } from '../lib/services'
+import { parsePinForm } from '../lib/form'
 import {
   getAuthUser,
   getSessionManager,
@@ -178,22 +179,16 @@ privateRouter.post('/pins/new', async (c) => {
   const ac = new AccessControl(user)
   const formData = await c.req.parseBody()
 
-  const getString = (value: unknown): string => {
-    if (typeof value === 'string') return value
-    if (Array.isArray(value)) return getString(value[0])
-    return ''
-  }
-
-  const pinUrl = getString(formData.url)
-  const title = getString(formData.title)
-  const description = getString(formData.description) || null
-  const readLater = getString(formData.readLater) === 'true'
-  const tagsInput = getString(formData.tags)
-
-  const tagNames = tagsInput
-    .split(',')
-    .map((t) => t.trim())
-    .filter((t) => t.length > 0)
+  // isPrivate is intentionally not read here: this form always stores a
+  // private pin, whatever the submitted value says.
+  const {
+    url: pinUrl,
+    title,
+    description,
+    readLater,
+    tagsInput,
+    tagNames,
+  } = parsePinForm(formData)
 
   const userTags = await tagService.getUserTags(ac, user.id)
 
@@ -352,23 +347,15 @@ privateRouter.post('/pins/:id/edit', async (c) => {
 
   const formData = await c.req.parseBody()
 
-  const getString = (value: unknown): string => {
-    if (typeof value === 'string') return value
-    if (Array.isArray(value)) return getString(value[0])
-    return ''
-  }
-
-  const pinUrl = getString(formData.url)
-  const title = getString(formData.title)
-  const description = getString(formData.description) || null
-  const readLater = getString(formData.readLater) === 'true'
-  const isPrivate = getString(formData.isPrivate) === 'true'
-  const tagsInput = getString(formData.tags)
-
-  const tagNames = tagsInput
-    .split(',')
-    .map((t) => t.trim())
-    .filter((t) => t.length > 0)
+  const {
+    url: pinUrl,
+    title,
+    description,
+    readLater,
+    isPrivate,
+    tagsInput,
+    tagNames,
+  } = parsePinForm(formData)
 
   const userTags = await tagService.getUserTags(ac, user.id)
 

--- a/apps/hono/src/routes/profile.tsx
+++ b/apps/hono/src/routes/profile.tsx
@@ -6,6 +6,7 @@ import {
   ValidationError,
 } from '@pinsquirrel/domain'
 import { apiKeyService, authService } from '../lib/services'
+import { getString } from '../lib/form'
 import {
   getAuthUser,
   getSessionManager,
@@ -40,13 +41,6 @@ profile.post('/', async (c) => {
 
   // Parse form data
   const formData = await c.req.parseBody()
-
-  // Helper to get string values
-  const getString = (value: unknown): string => {
-    if (typeof value === 'string') return value
-    if (Array.isArray(value)) return getString(value[0])
-    return ''
-  }
 
   const intent = getString(formData['intent'])
 

--- a/apps/hono/src/routes/tags.tsx
+++ b/apps/hono/src/routes/tags.tsx
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { AccessControl } from '@pinsquirrel/domain'
 import { pinService, tagService } from '../lib/services'
+import { getString } from '../lib/form'
 import {
   getAuthUser,
   getSessionManager,
@@ -91,13 +92,6 @@ tags.post('/merge', async (c) => {
 
   // Parse form data
   const formData = await c.req.parseBody()
-
-  // Helper to get string values
-  const getString = (value: unknown): string => {
-    if (typeof value === 'string') return value
-    if (Array.isArray(value)) return getString(value[0])
-    return ''
-  }
 
   // Get source tag IDs (comma-separated string from hidden input)
   let sourceTagIds: string[] = []


### PR DESCRIPTION
Step 3 of the simplification plan, on top of #85 (tests) and #86 (`requireAuth`).

## What was duplicated

`getString` — the coercion for Hono's `parseBody()` output, which hands back `string | File | array | undefined` per field — was declared **inline in six handler bodies**, identically each time.

But extracting only that would have missed the bigger duplicate. The pin create and edit handlers in `pins.tsx` and `private.tsx` each repeated the *same field block*: read six fields, map an empty description to `null`, compare two flags against the literal `'true'`, split and trim the tag input. **Four copies.**

New `lib/form.ts` with `getString`, `parseTagNames`, and `parsePinForm`.

```ts
const { url: pinUrl, title, description, readLater, isPrivate, tagsInput, tagNames } =
  parsePinForm(formData)
```

## The edge cases the inline copies encoded but never stated

11 unit tests now make them explicit:

- `File` values coerce to `''`, not `"[object File]"` — file inputs land in the same `parseBody()` result
- repeated fields collapse to their first entry, recursively
- an empty description becomes `null`, not `''` — it maps onto a nullable column
- `readLater` / `isPrivate` are true **only** for the literal string `'true'` (`'on'`, `'TRUE'`, `'1'` are all false)

## Keeping the asymmetry visible

`parsePinForm` reports `isPrivate` **as submitted** rather than forcing it. The private create form ignores it and always stores a private pin, so that override stays at the call site with a comment, where the decision is visible:

```ts
// isPrivate is intentionally not read here: this form always stores a
// private pin, whatever the submitted value says.
```

Burying it in the helper would have hidden exactly the divergence #85 was written to pin down — and which private *edit* does not share.

## Evidence

**All 70 pin-route characterization tests pass unchanged.** Full hono suite: 171 passed. `pnpm quality` green. Routes net **−29 lines**, plus a tested helper module replacing untested inline copies.

## A gap the mutation testing found

Checking the extraction was faithful, I mutated the helper. Two mutations escaped the *route* suite — and one mattered:

> Making `description` fall back to `''` instead of `null` was **not caught** by any route test, though the new unit tests caught it.

That value reaches a nullable column, so it now has a route-level assertion too. The route suite is the net for the upcoming factory work; it shouldn't rely on lower-level tests to catch a database-visible change. Re-running that mutation now fails the route suite.

## Next

The payoff step: `createPinRoutes` factory to collapse `private.tsx` into ~90 lines. The handlers are much smaller now that both the auth preamble and the form parsing are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)