### PR TITLE
refactor: share query building in the pin repository

### DIFF
--- a/libs/database/src/repositories/pagination.ts
+++ b/libs/database/src/repositories/pagination.ts
@@ -1,0 +1,33 @@
+/**
+ * MySQL rejects OFFSET unless LIMIT is present, and Drizzle emits exactly the
+ * clauses it is given. An offset-without-limit query therefore pairs the offset
+ * with the largest signed 32-bit integer — the conventional MySQL spelling of
+ * "everything from here on".
+ */
+export const OFFSET_WITHOUT_LIMIT = 2147483647
+
+/**
+ * A Drizzle `$dynamic()` query: chaining limit/offset returns the same type, so
+ * pagination can be applied conditionally without casting through `any`.
+ */
+export interface PaginatableQuery<T> {
+  limit(n: number): T
+  offset(n: number): T
+}
+
+/** Apply optional limit/offset to a `$dynamic()` query. */
+export function applyPagination<T extends PaginatableQuery<T>>(
+  query: T,
+  options?: { limit?: number; offset?: number }
+): T {
+  if (options?.limit !== undefined && options?.offset !== undefined) {
+    return query.limit(options.limit).offset(options.offset)
+  }
+  if (options?.limit !== undefined) {
+    return query.limit(options.limit)
+  }
+  if (options?.offset !== undefined) {
+    return query.limit(OFFSET_WITHOUT_LIMIT).offset(options.offset)
+  }
+  return query
+}

--- a/libs/database/src/repositories/pin.ts
+++ b/libs/database/src/repositories/pin.ts
@@ -20,12 +20,30 @@ import {
   sql,
 } from 'drizzle-orm'
 import type { MySql2Database } from 'drizzle-orm/mysql2'
+import { applyPagination } from './pagination.js'
 import { pins } from '../schema/pins.js'
 import { pinsTags } from '../schema/pins-tags.js'
 import { tags } from '../schema/tags.js'
 
 function md5(input: string): string {
   return createHash('md5').update(input).digest('hex')
+}
+
+/**
+ * The pin columns, listed explicitly because the tag-filtered queries join
+ * other tables and `select()` would widen the row to the joined shape.
+ */
+const PIN_COLUMNS = {
+  id: pins.id,
+  userId: pins.userId,
+  url: pins.url,
+  urlHash: pins.urlHash,
+  title: pins.title,
+  description: pins.description,
+  readLater: pins.readLater,
+  isPrivate: pins.isPrivate,
+  createdAt: pins.createdAt,
+  updatedAt: pins.updatedAt,
 }
 
 export class DrizzlePinRepository implements PinRepository {
@@ -63,244 +81,105 @@ export class DrizzlePinRepository implements PinRepository {
     return this.mapToPin(pin, pinTags)
   }
 
+  /**
+   * Conditions shared by every pin query for a user.
+   *
+   * `findByUserId` and `countByUserId` must agree exactly or a filtered list
+   * paginates against the wrong total, so they build their WHERE clause here
+   * rather than each maintaining its own copy.
+   */
+  private buildConditions(userId: string, filter?: PinFilter) {
+    const conditions = [eq(pins.userId, userId)]
+
+    if (filter?.readLater !== undefined) {
+      conditions.push(eq(pins.readLater, filter.readLater))
+    }
+
+    if (filter?.isPrivate !== undefined) {
+      conditions.push(eq(pins.isPrivate, filter.isPrivate))
+    }
+
+    if (filter?.url !== undefined) {
+      conditions.push(eq(pins.url, filter.url))
+    }
+
+    if (filter?.search !== undefined && filter.search.trim() !== '') {
+      const searchTerm = `%${filter.search}%`
+      const searchCondition = or(
+        like(pins.url, searchTerm),
+        like(pins.title, searchTerm),
+        like(pins.description, searchTerm)
+      )
+      if (searchCondition) {
+        conditions.push(searchCondition)
+      }
+    }
+
+    return conditions
+  }
+
   async findByUserId(
     userId: string,
     filter?: PinFilter,
     options?: { limit?: number; offset?: number }
   ): Promise<Pin[]> {
-    // Build query conditions
-    const conditions = [eq(pins.userId, userId)]
+    const conditions = this.buildConditions(userId, filter)
+    const orderBy = this.getOrderBy(filter)
 
-    // Add readLater filter if specified
-    if (filter?.readLater !== undefined) {
-      conditions.push(eq(pins.readLater, filter.readLater))
-    }
+    // Each tag filter needs its own join, so the branches differ in shape
+    // rather than just in a WHERE clause. `countByUserId` mirrors them exactly.
+    const select = () => this.db.select(PIN_COLUMNS).from(pins).$dynamic()
 
-    // Add isPrivate filter if specified
-    if (filter?.isPrivate !== undefined) {
-      conditions.push(eq(pins.isPrivate, filter.isPrivate))
-    }
-
-    // Add URL filter if specified (for findByUserIdAndUrl functionality)
-    if (filter?.url !== undefined) {
-      conditions.push(eq(pins.url, filter.url))
-    }
-
-    // Add search filter if specified
-    if (filter?.search !== undefined && filter.search.trim() !== '') {
-      const searchTerm = `%${filter.search}%`
-      const searchCondition = or(
-        like(pins.url, searchTerm),
-        like(pins.title, searchTerm),
-        like(pins.description, searchTerm)
-      )
-      if (searchCondition) {
-        conditions.push(searchCondition)
-      }
-    }
-
-    // If filtering by tag name, we need to join with tags
+    let query
     if (filter?.tag) {
-      const baseQuery = this.db
-        .select({
-          id: pins.id,
-          userId: pins.userId,
-          url: pins.url,
-          urlHash: pins.urlHash,
-          title: pins.title,
-          description: pins.description,
-          readLater: pins.readLater,
-          isPrivate: pins.isPrivate,
-          createdAt: pins.createdAt,
-          updatedAt: pins.updatedAt,
-        })
-        .from(pins)
+      query = select()
         .innerJoin(pinsTags, eq(pins.id, pinsTags.pinId))
         .innerJoin(tags, eq(pinsTags.tagId, tags.id))
         .where(and(...conditions, eq(tags.name, filter.tag)))
-        .orderBy(this.getOrderBy(filter))
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let query = baseQuery as any
-      if (options?.limit !== undefined && options?.offset !== undefined) {
-        query = baseQuery.limit(options.limit).offset(options.offset)
-      } else if (options?.limit !== undefined) {
-        query = baseQuery.limit(options.limit)
-      } else if (options?.offset !== undefined) {
-        query = baseQuery.limit(2147483647).offset(options.offset)
-      }
-
-      const results = await query
-
-      // Use mapPinsBulk to properly load tags for each pin
-      return this.mapPinsBulk(results)
-    }
-
-    // If filtering by tag ID, we need to join with pinsTags
-    if (filter?.tagId) {
-      const baseQuery = this.db
-        .select({
-          id: pins.id,
-          userId: pins.userId,
-          url: pins.url,
-          urlHash: pins.urlHash,
-          title: pins.title,
-          description: pins.description,
-          readLater: pins.readLater,
-          isPrivate: pins.isPrivate,
-          createdAt: pins.createdAt,
-          updatedAt: pins.updatedAt,
-        })
-        .from(pins)
+    } else if (filter?.tagId) {
+      query = select()
         .innerJoin(pinsTags, eq(pins.id, pinsTags.pinId))
         .where(and(...conditions, eq(pinsTags.tagId, filter.tagId)))
-        .orderBy(this.getOrderBy(filter))
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let query = baseQuery as any
-      if (options?.limit !== undefined && options?.offset !== undefined) {
-        query = baseQuery.limit(options.limit).offset(options.offset)
-      } else if (options?.limit !== undefined) {
-        query = baseQuery.limit(options.limit)
-      } else if (options?.offset !== undefined) {
-        query = baseQuery.limit(2147483647).offset(options.offset)
-      }
-
-      const results = await query
-
-      // Use mapPinsBulk to properly load tags for each pin
-      return this.mapPinsBulk(results)
-    }
-
-    // If filtering for pins with no tags, use LEFT JOIN to find pins without tag associations
-    if (filter?.noTags) {
-      const baseQuery = this.db
-        .select({
-          id: pins.id,
-          userId: pins.userId,
-          url: pins.url,
-          urlHash: pins.urlHash,
-          title: pins.title,
-          description: pins.description,
-          readLater: pins.readLater,
-          isPrivate: pins.isPrivate,
-          createdAt: pins.createdAt,
-          updatedAt: pins.updatedAt,
-        })
-        .from(pins)
+    } else if (filter?.noTags) {
+      // LEFT JOIN + IS NULL: pins with no tag associations at all.
+      query = select()
         .leftJoin(pinsTags, eq(pins.id, pinsTags.pinId))
         .where(and(...conditions, isNull(pinsTags.pinId)))
-        .orderBy(this.getOrderBy(filter))
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let query = baseQuery as any
-      if (options?.limit !== undefined && options?.offset !== undefined) {
-        query = baseQuery.limit(options.limit).offset(options.offset)
-      } else if (options?.limit !== undefined) {
-        query = baseQuery.limit(options.limit)
-      } else if (options?.offset !== undefined) {
-        query = baseQuery.limit(2147483647).offset(options.offset)
-      }
-
-      const results = await query
-
-      // Use mapPinsBulk to properly load tags for each pin
-      return this.mapPinsBulk(results)
+    } else {
+      query = select().where(and(...conditions))
     }
 
-    // Standard query without tag filtering
-    const baseQuery = this.db
-      .select()
-      .from(pins)
-      .where(and(...conditions))
-      .orderBy(this.getOrderBy(filter))
+    const results = await applyPagination(query.orderBy(orderBy), options)
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let query = baseQuery as any
-    if (options?.limit !== undefined && options?.offset !== undefined) {
-      query = baseQuery.limit(options.limit).offset(options.offset)
-    } else if (options?.limit !== undefined) {
-      query = baseQuery.limit(options.limit)
-    } else if (options?.offset !== undefined) {
-      query = baseQuery.limit(2147483647).offset(options.offset)
-    }
-
-    const result = await query
-
-    return this.mapPinsBulk(result)
+    return this.mapPinsBulk(results)
   }
 
   async countByUserId(userId: string, filter?: PinFilter): Promise<number> {
-    // Build query conditions
-    const conditions = [eq(pins.userId, userId)]
+    const conditions = this.buildConditions(userId, filter)
 
-    // Add readLater filter if specified
-    if (filter?.readLater !== undefined) {
-      conditions.push(eq(pins.readLater, filter.readLater))
-    }
+    // Mirrors the branches in findByUserId; only the projection differs.
+    const select = () =>
+      this.db.select({ count: count() }).from(pins).$dynamic()
 
-    // Add isPrivate filter if specified
-    if (filter?.isPrivate !== undefined) {
-      conditions.push(eq(pins.isPrivate, filter.isPrivate))
-    }
-
-    // Add URL filter if specified
-    if (filter?.url !== undefined) {
-      conditions.push(eq(pins.url, filter.url))
-    }
-
-    // Add search filter if specified
-    if (filter?.search !== undefined && filter.search.trim() !== '') {
-      const searchTerm = `%${filter.search}%`
-      const searchCondition = or(
-        like(pins.url, searchTerm),
-        like(pins.title, searchTerm),
-        like(pins.description, searchTerm)
-      )
-      if (searchCondition) {
-        conditions.push(searchCondition)
-      }
-    }
-
-    // If filtering by tag name, we need to join with tags
+    let query
     if (filter?.tag) {
-      const result = await this.db
-        .select({ count: count() })
-        .from(pins)
+      query = select()
         .innerJoin(pinsTags, eq(pins.id, pinsTags.pinId))
         .innerJoin(tags, eq(pinsTags.tagId, tags.id))
         .where(and(...conditions, eq(tags.name, filter.tag)))
-
-      return result[0]?.count ?? 0
-    }
-
-    // If filtering by tag ID, we need to join with pinsTags
-    if (filter?.tagId) {
-      const result = await this.db
-        .select({ count: count() })
-        .from(pins)
+    } else if (filter?.tagId) {
+      query = select()
         .innerJoin(pinsTags, eq(pins.id, pinsTags.pinId))
         .where(and(...conditions, eq(pinsTags.tagId, filter.tagId)))
-
-      return result[0]?.count ?? 0
-    }
-
-    // If filtering for pins with no tags, use LEFT JOIN to count pins without tag associations
-    if (filter?.noTags) {
-      const result = await this.db
-        .select({ count: count() })
-        .from(pins)
+    } else if (filter?.noTags) {
+      query = select()
         .leftJoin(pinsTags, eq(pins.id, pinsTags.pinId))
         .where(and(...conditions, isNull(pinsTags.pinId)))
-
-      return result[0]?.count ?? 0
+    } else {
+      query = select().where(and(...conditions))
     }
 
-    // Standard count without tag filtering
-    const result = await this.db
-      .select({ count: count() })
-      .from(pins)
-      .where(and(...conditions))
+    const result = await query
 
     return result[0]?.count ?? 0
   }

--- a/libs/database/src/repositories/tag.ts
+++ b/libs/database/src/repositories/tag.ts
@@ -10,6 +10,7 @@ import type {
 import { tags } from '../schema/tags.js'
 import { pinsTags } from '../schema/pins-tags.js'
 import { pins } from '../schema/pins.js'
+import { OFFSET_WITHOUT_LIMIT } from './pagination.js'
 
 export class DrizzleTagRepository implements TagRepository {
   constructor(private db: MySql2Database<Record<string, unknown>>) {}
@@ -166,7 +167,7 @@ export class DrizzleTagRepository implements TagRepository {
     } else if (limit !== undefined) {
       query = baseQuery.limit(limit)
     } else if (offset !== undefined) {
-      query = baseQuery.limit(2147483647).offset(offset)
+      query = baseQuery.limit(OFFSET_WITHOUT_LIMIT).offset(offset)
     } else {
       query = baseQuery
     }

--- a/libs/database/src/repositories/user.ts
+++ b/libs/database/src/repositories/user.ts
@@ -10,6 +10,7 @@ import { eq, and, sql } from 'drizzle-orm'
 import type { MySql2Database } from 'drizzle-orm/mysql2'
 import { users } from '../schema/users.js'
 import { userRoles } from '../schema/user-roles.js'
+import { OFFSET_WITHOUT_LIMIT } from './pagination.js'
 
 export class DrizzleUserRepository implements UserRepository {
   constructor(private db: MySql2Database<Record<string, unknown>>) {}
@@ -87,7 +88,7 @@ export class DrizzleUserRepository implements UserRepository {
       results = await this.db
         .select()
         .from(users)
-        .limit(2147483647)
+        .limit(OFFSET_WITHOUT_LIMIT)
         .offset(offset)
     } else {
       results = await this.db.select().from(users)


### PR DESCRIPTION
The last item from the simplification review. Isolated to `libs/database`, and unlike the route work it needed no new tests — this code already has real MySQL integration coverage.

## Two copies that had to agree

`findByUserId` and `countByUserId` each opened with the same **~30 lines of condition building**, comments included, then branched four ways (`tag`, `tagId`, `noTags`, default) over the same joins.

That duplication isn't cosmetic: if the two drift, **a filtered list paginates against a total computed by a different query**. They now share `buildConditions`, and their branches are written to mirror each other with only the projection differing.

## The last `as any` in the codebase

The eight-line limit/offset block appeared **four times** in this one file, each copy carrying an `as any` and an unexplained `2147483647`:

```ts
// eslint-disable-next-line @typescript-eslint/no-explicit-any
let query = baseQuery as any
if (options?.limit !== undefined && options?.offset !== undefined) { ... }
```

Those casts were working around Drizzle's builder type changing when you conditionally chain `.limit()`. Drizzle has `$dynamic()` for precisely that — it keeps the type stable — so one typed `applyPagination` replaces all four.

**That removes the last `as any` in the entire repo.** All four lived here.

## The magic number

`2147483647` is the MySQL "no limit" idiom, needed because MySQL rejects `OFFSET` without `LIMIT`. It appeared in `pin.ts`, `tag.ts`, and `user.ts` with no explanation anywhere. It's now `OFFSET_WITHOUT_LIMIT` in a shared module, documented once.

## Result

| | Before | After |
|---|---:|---:|
| `pin.ts` | 493 | **372** |
| `pagination.ts` | — | 33 |

**Coverage of `pin.ts` rises 82.8% → 92.9%** of statements *without new tests* — the duplicated branches collapsed into shared code that every existing test already exercises.

## Deliberately limited

`tag.ts` and `user.ts` get the named constant but **keep their own pagination chains**. Their `list()` methods sit in the uncovered ranges (35% and 10% file coverage), and restructuring untested query building is exactly what this whole effort has been avoiding. Swapping a literal for a named constant has no behavioral surface; rewriting their control flow does.

If you want those tidied too, the honest order is tests first — same as #85.

## Verification

Verified against the **real MySQL integration suite**, not mocks: 162 database tests pass, including the `tag`/`tagId`/`noTags` branches this consolidates. CI runs the same suite against its own MySQL service.

`pnpm quality` green, `pnpm build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)