### PR TITLE
test: cover TagService

### DIFF
--- a/libs/services/src/services/tag.test.ts
+++ b/libs/services/src/services/tag.test.ts
@@ -1,59 +1,103 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { TagService } from './tag.js'
-import type { TagRepository, Tag, User } from '@pinsquirrel/domain'
+import type {
+  TagRepository,
+  Tag,
+  TagWithCount,
+  User,
+} from '@pinsquirrel/domain'
 import {
   AccessControl,
   Role,
   TagNotFoundError,
+  UnauthorizedTagAccessError,
   UserStatus,
+  ValidationError,
 } from '@pinsquirrel/domain'
 
-describe('TagService.getUserTagById', () => {
-  let service: TagService
-  let mockRepo: TagRepository
+const owner: User = {
+  id: 'owner-id',
+  username: 'owner',
+  passwordHash: 'x',
+  emailHash: null,
+  emailEncrypted: null,
+  roles: [Role.User],
+  status: UserStatus.Active,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+}
 
-  const owner: User = {
-    id: 'owner-id',
-    username: 'owner',
-    passwordHash: 'x',
-    emailHash: null,
-    emailEncrypted: null,
-    roles: [Role.User],
-    status: UserStatus.Active,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  }
+const otherUser: User = {
+  ...owner,
+  id: 'other-id',
+  username: 'other',
+}
 
-  const otherUser: User = {
-    ...owner,
-    id: 'other-id',
-    username: 'other',
-  }
-
-  const tag: Tag = {
+function makeTag(overrides: Partial<Tag> = {}): Tag {
+  return {
     id: 'tag-1',
     userId: 'owner-id',
     name: 'foo',
     createdAt: new Date(),
     updatedAt: new Date(),
+    ...overrides,
   }
+}
 
-  beforeEach(() => {
-    mockRepo = {
-      findById: vi.fn(),
-      findByUserId: vi.fn(),
-      findByUserIdAndName: vi.fn(),
-      fetchOrCreateByNames: vi.fn(),
-      findByUserIdWithPinCount: vi.fn(),
-      mergeTags: vi.fn(),
-      deleteTagsWithNoPins: vi.fn(),
-      create: vi.fn(),
-      update: vi.fn(),
-      delete: vi.fn(),
-    } as unknown as TagRepository
-    service = new TagService(mockRepo)
+const tag = makeTag()
+
+/** A tag belonging to somebody else — the case every ownership check exists for. */
+const foreignTag = makeTag({ id: 'tag-x', userId: 'other-id' })
+
+let service: TagService
+let mockRepo: TagRepository
+
+beforeEach(() => {
+  mockRepo = {
+    findById: vi.fn(),
+    findByUserId: vi.fn(),
+    findByUserIdAndName: vi.fn(),
+    fetchOrCreateByNames: vi.fn(),
+    findByUserIdWithPinCount: vi.fn(),
+    mergeTags: vi.fn(),
+    deleteTagsWithNoPins: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as TagRepository
+  service = new TagService(mockRepo)
+})
+
+describe('TagService.getUserTags', () => {
+  it('returns the caller’s own tags', async () => {
+    vi.mocked(mockRepo.findByUserId).mockResolvedValue([tag])
+
+    await expect(
+      service.getUserTags(new AccessControl(owner), 'owner-id')
+    ).resolves.toEqual([tag])
+    expect(mockRepo.findByUserId).toHaveBeenCalledWith('owner-id')
   })
 
+  it('filters out tags the caller cannot read', async () => {
+    // The repository is asked for a userId, but the result is still gated:
+    // passing someone else's id must not hand back their tags.
+    vi.mocked(mockRepo.findByUserId).mockResolvedValue([tag, foreignTag])
+
+    await expect(
+      service.getUserTags(new AccessControl(otherUser), 'owner-id')
+    ).resolves.toEqual([foreignTag])
+  })
+
+  it('returns nothing for an unauthenticated caller', async () => {
+    vi.mocked(mockRepo.findByUserId).mockResolvedValue([tag, foreignTag])
+
+    await expect(
+      service.getUserTags(new AccessControl(null), 'owner-id')
+    ).resolves.toEqual([])
+  })
+})
+
+describe('TagService.getUserTagById', () => {
   it('returns the tag when owned by the caller', async () => {
     vi.mocked(mockRepo.findById).mockResolvedValue(tag)
     const ac = new AccessControl(owner)
@@ -82,5 +126,304 @@ describe('TagService.getUserTagById', () => {
     await expect(service.getUserTagById(ac, 'tag-1')).rejects.toBeInstanceOf(
       TagNotFoundError
     )
+  })
+})
+
+describe('TagService.getUserTagsWithCount', () => {
+  const counted: TagWithCount = { ...tag, pinCount: 3 }
+  const foreignCounted: TagWithCount = { ...foreignTag, pinCount: 9 }
+
+  it('returns counts for the caller’s own tags', async () => {
+    vi.mocked(mockRepo.findByUserIdWithPinCount).mockResolvedValue([counted])
+
+    await expect(
+      service.getUserTagsWithCount(new AccessControl(owner), 'owner-id')
+    ).resolves.toEqual([counted])
+  })
+
+  it('passes the pin filter through to the repository', async () => {
+    vi.mocked(mockRepo.findByUserIdWithPinCount).mockResolvedValue([])
+
+    await service.getUserTagsWithCount(new AccessControl(owner), 'owner-id', {
+      isPrivate: true,
+    })
+
+    expect(mockRepo.findByUserIdWithPinCount).toHaveBeenCalledWith('owner-id', {
+      isPrivate: true,
+    })
+  })
+
+  it('filters out tags the caller cannot read', async () => {
+    vi.mocked(mockRepo.findByUserIdWithPinCount).mockResolvedValue([
+      counted,
+      foreignCounted,
+    ])
+
+    await expect(
+      service.getUserTagsWithCount(new AccessControl(otherUser), 'owner-id')
+    ).resolves.toEqual([foreignCounted])
+  })
+
+  it('returns nothing for an unauthenticated caller', async () => {
+    vi.mocked(mockRepo.findByUserIdWithPinCount).mockResolvedValue([counted])
+
+    await expect(
+      service.getUserTagsWithCount(new AccessControl(null), 'owner-id')
+    ).resolves.toEqual([])
+  })
+})
+
+describe('TagService.createTag', () => {
+  it('creates a tag for the caller', async () => {
+    vi.mocked(mockRepo.create).mockResolvedValue(tag)
+
+    await expect(
+      service.createTag(new AccessControl(owner), {
+        userId: 'owner-id',
+        name: 'foo',
+      })
+    ).resolves.toEqual(tag)
+    expect(mockRepo.create).toHaveBeenCalledWith({
+      userId: 'owner-id',
+      name: 'foo',
+    })
+  })
+
+  it('refuses to create a tag owned by someone else', async () => {
+    await expect(
+      service.createTag(new AccessControl(owner), {
+        userId: 'other-id',
+        name: 'foo',
+      })
+    ).rejects.toBeInstanceOf(UnauthorizedTagAccessError)
+    expect(mockRepo.create).not.toHaveBeenCalled()
+  })
+
+  it('refuses an unauthenticated caller', async () => {
+    await expect(
+      service.createTag(new AccessControl(null), {
+        userId: 'owner-id',
+        name: 'foo',
+      })
+    ).rejects.toBeInstanceOf(UnauthorizedTagAccessError)
+    expect(mockRepo.create).not.toHaveBeenCalled()
+  })
+
+  it('normalises the name to trimmed lowercase before storing', async () => {
+    vi.mocked(mockRepo.create).mockResolvedValue(tag)
+
+    await service.createTag(new AccessControl(owner), {
+      userId: 'owner-id',
+      name: '  FooBar  ',
+    })
+
+    expect(mockRepo.create).toHaveBeenCalledWith({
+      userId: 'owner-id',
+      name: 'foobar',
+    })
+  })
+
+  it.each([
+    ['empty', ''],
+    ['whitespace only', '   '],
+    ['over 50 characters', 'x'.repeat(51)],
+    // Written as an escape on purpose: a literal NUL in the source is
+    // invisible, reads as a space, and does not survive tooling that
+    // rewrites the file.
+    ['containing a control character', 'foo\x00bar'],
+  ])('rejects a name that is %s', async (_label, name) => {
+    await expect(
+      service.createTag(new AccessControl(owner), { userId: 'owner-id', name })
+    ).rejects.toBeInstanceOf(ValidationError)
+    expect(mockRepo.create).not.toHaveBeenCalled()
+  })
+
+  it('checks ownership before validating the name', async () => {
+    // Order matters: an unauthorized caller should be told they are
+    // unauthorized, not handed a validation error that confirms nothing.
+    await expect(
+      service.createTag(new AccessControl(owner), {
+        userId: 'other-id',
+        name: '',
+      })
+    ).rejects.toBeInstanceOf(UnauthorizedTagAccessError)
+  })
+})
+
+describe('TagService.mergeTags', () => {
+  const targetTag = makeTag({ id: 'target' })
+  const sourceA = makeTag({ id: 'src-a' })
+  const sourceB = makeTag({ id: 'src-b' })
+
+  it('merges when the caller owns the target and every source', async () => {
+    vi.mocked(mockRepo.findById).mockImplementation((id: string) =>
+      Promise.resolve(
+        { target: targetTag, 'src-a': sourceA, 'src-b': sourceB }[id] ?? null
+      )
+    )
+
+    await service.mergeTags(
+      new AccessControl(owner),
+      ['src-a', 'src-b'],
+      'target'
+    )
+
+    expect(mockRepo.mergeTags).toHaveBeenCalledWith(
+      'owner-id',
+      ['src-a', 'src-b'],
+      'target'
+    )
+  })
+
+  it('refuses an unauthenticated caller', async () => {
+    await expect(
+      service.mergeTags(new AccessControl(null), ['src-a'], 'target')
+    ).rejects.toBeInstanceOf(UnauthorizedTagAccessError)
+    expect(mockRepo.findById).not.toHaveBeenCalled()
+    expect(mockRepo.mergeTags).not.toHaveBeenCalled()
+  })
+
+  it('throws when the target tag does not exist', async () => {
+    vi.mocked(mockRepo.findById).mockResolvedValue(null)
+
+    await expect(
+      service.mergeTags(new AccessControl(owner), ['src-a'], 'target')
+    ).rejects.toBeInstanceOf(TagNotFoundError)
+    expect(mockRepo.mergeTags).not.toHaveBeenCalled()
+  })
+
+  it('refuses to merge into a target owned by someone else', async () => {
+    // The sources are deliberately owned by the caller. If they were not, the
+    // source-ownership loop would throw too and this test would pass even with
+    // the target check deleted — which is exactly what mutation testing caught.
+    vi.mocked(mockRepo.findById).mockImplementation((id: string) =>
+      Promise.resolve({ 'tag-x': foreignTag, 'src-a': sourceA }[id] ?? null)
+    )
+
+    await expect(
+      service.mergeTags(new AccessControl(owner), ['src-a'], 'tag-x')
+    ).rejects.toBeInstanceOf(UnauthorizedTagAccessError)
+    expect(mockRepo.mergeTags).not.toHaveBeenCalled()
+  })
+
+  it('throws when any source tag does not exist', async () => {
+    vi.mocked(mockRepo.findById).mockImplementation((id: string) =>
+      Promise.resolve(id === 'target' ? targetTag : null)
+    )
+
+    await expect(
+      service.mergeTags(new AccessControl(owner), ['missing'], 'target')
+    ).rejects.toBeInstanceOf(TagNotFoundError)
+    expect(mockRepo.mergeTags).not.toHaveBeenCalled()
+  })
+
+  it('refuses when ANY source belongs to someone else, not just the first', async () => {
+    // The loop must check every source. A check that stopped after the first
+    // would let a foreign tag ride along in a multi-tag merge — the exact
+    // hole this ownership loop exists to close.
+    vi.mocked(mockRepo.findById).mockImplementation((id: string) =>
+      Promise.resolve(
+        { target: targetTag, 'src-a': sourceA, 'tag-x': foreignTag }[id] ?? null
+      )
+    )
+
+    await expect(
+      service.mergeTags(new AccessControl(owner), ['src-a', 'tag-x'], 'target')
+    ).rejects.toBeInstanceOf(UnauthorizedTagAccessError)
+    expect(mockRepo.mergeTags).not.toHaveBeenCalled()
+  })
+
+  it('validates every source before performing the merge', async () => {
+    vi.mocked(mockRepo.findById).mockImplementation((id: string) =>
+      Promise.resolve(
+        { target: targetTag, 'src-a': sourceA, 'src-b': sourceB }[id] ?? null
+      )
+    )
+
+    await service.mergeTags(
+      new AccessControl(owner),
+      ['src-a', 'src-b'],
+      'target'
+    )
+
+    // Target plus both sources — nothing merged on a partial check.
+    expect(mockRepo.findById).toHaveBeenCalledTimes(3)
+  })
+
+  it('merges under the caller’s id, not an id supplied by the request', async () => {
+    vi.mocked(mockRepo.findById).mockResolvedValue(targetTag)
+
+    await service.mergeTags(new AccessControl(owner), [], 'target')
+
+    expect(mockRepo.mergeTags).toHaveBeenCalledWith('owner-id', [], 'target')
+  })
+})
+
+describe('TagService.deleteTag', () => {
+  it('deletes a tag the caller owns', async () => {
+    vi.mocked(mockRepo.findById).mockResolvedValue(tag)
+    vi.mocked(mockRepo.delete).mockResolvedValue(true)
+
+    await service.deleteTag(new AccessControl(owner), 'tag-1')
+
+    expect(mockRepo.delete).toHaveBeenCalledWith('tag-1')
+  })
+
+  it('throws when the tag does not exist', async () => {
+    vi.mocked(mockRepo.findById).mockResolvedValue(null)
+
+    await expect(
+      service.deleteTag(new AccessControl(owner), 'tag-1')
+    ).rejects.toBeInstanceOf(TagNotFoundError)
+    expect(mockRepo.delete).not.toHaveBeenCalled()
+  })
+
+  it('refuses to delete a tag owned by someone else', async () => {
+    vi.mocked(mockRepo.findById).mockResolvedValue(foreignTag)
+
+    await expect(
+      service.deleteTag(new AccessControl(owner), 'tag-x')
+    ).rejects.toBeInstanceOf(UnauthorizedTagAccessError)
+    expect(mockRepo.delete).not.toHaveBeenCalled()
+  })
+
+  it('refuses an unauthenticated caller', async () => {
+    vi.mocked(mockRepo.findById).mockResolvedValue(tag)
+
+    await expect(
+      service.deleteTag(new AccessControl(null), 'tag-1')
+    ).rejects.toBeInstanceOf(UnauthorizedTagAccessError)
+    expect(mockRepo.delete).not.toHaveBeenCalled()
+  })
+
+  it('throws when the repository reports nothing was deleted', async () => {
+    vi.mocked(mockRepo.findById).mockResolvedValue(tag)
+    vi.mocked(mockRepo.delete).mockResolvedValue(false)
+
+    await expect(
+      service.deleteTag(new AccessControl(owner), 'tag-1')
+    ).rejects.toBeInstanceOf(TagNotFoundError)
+  })
+})
+
+describe('TagService.deleteTagsWithNoPins', () => {
+  it('cleans up the caller’s own orphan tags', async () => {
+    await service.deleteTagsWithNoPins(new AccessControl(owner), 'owner-id')
+
+    expect(mockRepo.deleteTagsWithNoPins).toHaveBeenCalledWith('owner-id')
+  })
+
+  it('refuses to clean up another user’s tags', async () => {
+    await expect(
+      service.deleteTagsWithNoPins(new AccessControl(owner), 'other-id')
+    ).rejects.toBeInstanceOf(UnauthorizedTagAccessError)
+    expect(mockRepo.deleteTagsWithNoPins).not.toHaveBeenCalled()
+  })
+
+  it('refuses an unauthenticated caller', async () => {
+    await expect(
+      service.deleteTagsWithNoPins(new AccessControl(null), 'owner-id')
+    ).rejects.toBeInstanceOf(UnauthorizedTagAccessError)
+    expect(mockRepo.deleteTagsWithNoPins).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
The last real test gap. **36 tests (up from 4), no production changes.**

Coverage **11.6% → 100%** of statements, branches, functions and lines.

## Why this one

`TagService` had a test file, which is exactly why the gap was easy to miss — the service *looked* tested. That file covered `getUserTagById` and nothing else. Unverified: `getUserTags`, `getUserTagsWithCount`, `createTag`, `deleteTag`, `deleteTagsWithNoPins`, and `mergeTags`.

`mergeTags` is the reason it mattered. It's destructive, and its safety rests entirely on ownership checks it performs in a loop — the target tag, then **every source tag individually**. Nothing verified any of them, and both the web UI and `/api/v1` reach it.

Existing fixtures were hoisted rather than duplicated, so all seven `describe` blocks share one repository mock and one pair of users.

## Two escapes from the mutation sweep

9 deliberate changes, one per authorization check. **7 caught immediately.** Both escapes were informative:

**1. Deleting the target-ownership check in `mergeTags` was NOT caught** — a real gap, and in the most important method.

My test mocked `findById` to return a foreign tag for *every* id, so when the target check was removed, the **source**-ownership loop threw instead and the assertion passed for the wrong reason. It now uses a discriminating mock — foreign target, caller-owned source — so only the target check can produce that error. Re-running the mutation now fails.

**2. Replacing `ac.user!.id` with `targetTag.userId` was also not caught — but that's an equivalent mutant, not a gap.** `canUpdate` is strict ownership (`this.user.id === ag.userId`, no role escalation), so once that check passes the two expressions are the same value by construction. I left it rather than contorting a test to chase something unkillable.

## One oddity worth flagging

The control-character fixture contained a **literal NUL byte**, which renders as a space. It made the case look like it asserted nothing — it did assert correctly, but invisibly, and I burned a while proving it wasn't a false positive. (A `sed` I ran to test that theory silently didn't match, which was itself the clue.)

Replaced with an explicit `\x00` escape plus a comment. Same assertion, now visible and robust against tooling that rewrites the file.

## Verification

`pnpm quality` green. Services package coverage 86% → 95.3%. `tag.ts` is untouched — confirmed clean after every mutation was reverted.

## After this

No remaining test gaps I'd act on. `pin.ts`'s `getUserPinsWithPagination` is uncovered at the service level but exercised through route and repository tests; mailgun templates sit at 50% and are email HTML. Phase 6 is unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)