### PR TITLE
fix: stop the REST API exposing private pins

### DIFF
--- a/apps/hono/src/mcp/server.ts
+++ b/apps/hono/src/mcp/server.ts
@@ -1,6 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StreamableHTTPTransport } from '@hono/mcp'
-import { AccessControl, PinNotFoundError, type User } from '@pinsquirrel/domain'
+import { AccessControl, type User } from '@pinsquirrel/domain'
 import {
   pinListInputSchema,
   pinGetInputSchema,
@@ -38,7 +38,7 @@ server.registerTool(
       const input = args as PinListInput
       const result = await pinService.getUserPinsWithPagination(
         ac,
-        { ...pinFilterFromInput(input), isPrivate: false },
+        pinFilterFromInput(input),
         { page: input.page, pageSize: input.pageSize }
       )
       return {
@@ -62,10 +62,7 @@ server.registerTool(
     try {
       const user = getUserFromExtra(extra)
       const ac = new AccessControl(user)
-      const pin = await pinService.getPin(ac, id)
-      if (pin.isPrivate) {
-        return mapDomainErrorToMcp(new PinNotFoundError(id))
-      }
+      const pin = await pinService.getPublicPin(ac, id)
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(pin) }],
       }

--- a/apps/hono/src/routes/api-v1.test.ts
+++ b/apps/hono/src/routes/api-v1.test.ts
@@ -1,11 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { Hono } from 'hono'
 import type { ApiKey, Pin, Tag, TagWithCount, User } from '@pinsquirrel/domain'
-import { Pagination, TagNotFoundError } from '@pinsquirrel/domain'
+import {
+  Pagination,
+  PinNotFoundError,
+  TagNotFoundError,
+} from '@pinsquirrel/domain'
 
 const mockAuthenticateByKey = vi.fn()
 const mockFindUserById = vi.fn()
 const mockGetPin = vi.fn()
+const mockGetPublicPin = vi.fn()
 const mockGetUserPinsWithPagination = vi.fn()
 const mockGetUserTags = vi.fn()
 const mockGetUserTagsWithCount = vi.fn()
@@ -18,6 +23,7 @@ vi.mock('../lib/services', () => ({
   },
   pinService: {
     getPin: (...args: unknown[]) => mockGetPin(...args) as unknown,
+    getPublicPin: (...args: unknown[]) => mockGetPublicPin(...args) as unknown,
     getUserPinsWithPagination: (...args: unknown[]) =>
       mockGetUserPinsWithPagination(...args) as unknown,
   },
@@ -159,11 +165,12 @@ describe('api-v1 routes', () => {
       expect(body.pagination.totalCount).toBe(1)
       expect(body.pagination.page).toBe(1)
       expect(body.pagination.hasNext).toBe(false)
-      // isPrivate defaults to undefined (no filter) when not specified
+      // The API is public-only: the filter always excludes private pins,
+      // and there is no query parameter that can turn that off.
       const filter = mockGetUserPinsWithPagination.mock.calls[0][1] as {
         isPrivate: boolean | undefined
       }
-      expect(filter.isPrivate).toBeUndefined()
+      expect(filter.isPrivate).toBe(false)
     })
 
     it('passes query params through to service', async () => {
@@ -201,7 +208,7 @@ describe('api-v1 routes', () => {
     })
 
     it('returns pin', async () => {
-      mockGetPin.mockResolvedValue(makePin())
+      mockGetPublicPin.mockResolvedValue(makePin())
       const res = await app.request('/api/v1/pins/pin-1', {
         headers: { Authorization: 'Bearer ps_ok' },
       })
@@ -210,14 +217,14 @@ describe('api-v1 routes', () => {
       expect(body.id).toBe('pin-1')
     })
 
-    it('returns private pins', async () => {
-      mockGetPin.mockResolvedValue(makePin({ isPrivate: true }))
+    // Was the opposite until the REST API was brought in line with MCP: the
+    // same key could read a private pin here but not over the MCP server.
+    it('reports a private pin as not found', async () => {
+      mockGetPublicPin.mockRejectedValue(new PinNotFoundError('pin-1'))
       const res = await app.request('/api/v1/pins/pin-1', {
         headers: { Authorization: 'Bearer ps_ok' },
       })
-      expect(res.status).toBe(200)
-      const body = (await res.json()) as { isPrivate: boolean }
-      expect(body.isPrivate).toBe(true)
+      expect(res.status).toBe(404)
     })
   })
 
@@ -271,7 +278,8 @@ describe('api-v1 routes', () => {
         isPrivate: boolean | undefined
       }
       expect(filter.tag).toBe('foo')
-      expect(filter.isPrivate).toBeUndefined()
+      // Tag listings are public-only too.
+      expect(filter.isPrivate).toBe(false)
     })
 
     it('returns 404 when tag service throws TagNotFoundError', async () => {

--- a/apps/hono/src/routes/api-v1.ts
+++ b/apps/hono/src/routes/api-v1.ts
@@ -222,7 +222,7 @@ apiV1.get('/pins/:id', async (c) => {
   const id = c.req.param('id')
 
   try {
-    const pin = await pinService.getPin(ac, id)
+    const pin = await pinService.getPublicPin(ac, id)
     return c.json(pin)
   } catch (err) {
     return errorResponse(c, err)

--- a/libs/services/src/services/pin.test.ts
+++ b/libs/services/src/services/pin.test.ts
@@ -462,6 +462,51 @@ describe('PinService', () => {
     })
   })
 
+  describe('getPublicPin', () => {
+    it('should return a public pin owned by the user', async () => {
+      mockPinRepository.findById.mockResolvedValue(mockPin)
+
+      const result = await pinService.getPublicPin(
+        createMockAccessControl(mockUser),
+        'pin-123'
+      )
+
+      expect(result).toEqual(mockPin)
+    })
+
+    // Reported as missing rather than forbidden: a caller restricted to public
+    // pins must not be able to tell an existing private pin from no pin.
+    it('should throw PinNotFoundError for a private pin the user owns', async () => {
+      mockPinRepository.findById.mockResolvedValue({
+        ...mockPin,
+        isPrivate: true,
+      })
+
+      await expect(
+        pinService.getPublicPin(createMockAccessControl(mockUser), 'pin-123')
+      ).rejects.toThrow(PinNotFoundError)
+    })
+
+    it('should throw PinNotFoundError if the pin does not exist', async () => {
+      mockPinRepository.findById.mockResolvedValue(null)
+
+      await expect(
+        pinService.getPublicPin(createMockAccessControl(mockUser), 'pin-123')
+      ).rejects.toThrow(PinNotFoundError)
+    })
+
+    it("should throw UnauthorizedPinAccessError for another user's pin", async () => {
+      mockPinRepository.findById.mockResolvedValue({
+        ...mockPin,
+        userId: 'other-user',
+      })
+
+      await expect(
+        pinService.getPublicPin(createMockAccessControl(mockUser), 'pin-123')
+      ).rejects.toThrow(UnauthorizedPinAccessError)
+    })
+  })
+
   describe('isPrivate', () => {
     it('should create a pin with isPrivate true', async () => {
       mockPinRepository.findByUserIdAndUrl.mockResolvedValue(null)

--- a/libs/services/src/services/pin.ts
+++ b/libs/services/src/services/pin.ts
@@ -170,6 +170,22 @@ export class PinService {
     return pin
   }
 
+  /**
+   * Get a pin that the caller is allowed to see over a public-only surface.
+   *
+   * The REST API and the MCP server both authenticate with an API key and
+   * expose public pins only. A private pin is reported as missing rather than
+   * forbidden, so a caller cannot use the error to tell an existing private
+   * pin apart from no pin at all.
+   */
+  async getPublicPin(ac: AccessControl, pinId: string): Promise<Pin> {
+    const pin = await this.getPin(ac, pinId)
+    if (pin.isPrivate) {
+      throw new PinNotFoundError(pinId)
+    }
+    return pin
+  }
+
   async getUserPins(ac: AccessControl): Promise<Pin[]> {
     if (!ac.user) {
       throw new UnauthorizedPinAccessError(

--- a/libs/services/src/validation/pin-query.test.ts
+++ b/libs/services/src/validation/pin-query.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { pinListInputSchema, tagListInputSchema } from './pin-query.js'
+import {
+  pinFilterFromInput,
+  pinListInputSchema,
+  tagListInputSchema,
+} from './pin-query.js'
 
 describe('pinListInputSchema', () => {
   it('parses empty input', () => {
@@ -71,5 +75,47 @@ describe('tagListInputSchema', () => {
 
   it('accepts empty input', () => {
     expect(tagListInputSchema.parse({})).toEqual({})
+  })
+})
+
+describe('pinFilterFromInput', () => {
+  // Both callers — the REST API and the MCP server — are public-only surfaces.
+  // Forcing the flag here is what keeps them from drifting apart again.
+  it('always excludes private pins', () => {
+    expect(pinFilterFromInput({}).isPrivate).toBe(false)
+  })
+
+  it('cannot be talked into including private pins', () => {
+    const filter = pinFilterFromInput({
+      isPrivate: true,
+    } as unknown as Parameters<typeof pinFilterFromInput>[0])
+
+    expect(filter.isPrivate).toBe(false)
+  })
+
+  it('passes the remaining filters through', () => {
+    const filter = pinFilterFromInput({
+      tag: 'reading',
+      search: 'rust',
+      readLater: true,
+      noTags: false,
+      sortBy: 'title',
+      sortDirection: 'asc',
+    })
+
+    expect(filter).toMatchObject({
+      tag: 'reading',
+      search: 'rust',
+      readLater: true,
+      noTags: false,
+      sortBy: 'title',
+      sortDirection: 'asc',
+    })
+  })
+})
+
+describe('pinListInputSchema isPrivate', () => {
+  it('drops isPrivate rather than honouring it', () => {
+    expect(pinListInputSchema.parse({ isPrivate: true })).toEqual({})
   })
 })

--- a/libs/services/src/validation/pin-query.ts
+++ b/libs/services/src/validation/pin-query.ts
@@ -21,7 +21,6 @@ export const pinListInputSchema = z.object({
     .describe('Search pins by keyword'),
   readLater: z.boolean().optional().describe('Filter to read-later pins only'),
   noTags: z.boolean().optional().describe('Filter to pins with no tags'),
-  isPrivate: z.boolean().optional().describe('Filter by private status'),
   sortBy: z.enum(['created', 'title']).optional().describe('Sort field'),
   sortDirection: z.enum(['asc', 'desc']).optional().describe('Sort direction'),
   page: z.number().int().min(1).optional().describe('Page number (1-indexed)'),
@@ -49,14 +48,17 @@ export type TagListInput = z.infer<typeof tagListInputSchema>
 /**
  * Translate a validated `PinListInput` into a domain `PinFilter`.
  *
- * Both the REST API and MCP transport accept the same logical input shape,
- * so the conversion lives here as a single source of truth. Callers that
- * need to enforce additional constraints (e.g. forcing `isPrivate: false`
- * for public-only endpoints) should override after calling this helper.
+ * Both callers — the REST API and the MCP server — authenticate with an API
+ * key and expose public pins only, so `isPrivate: false` is forced here rather
+ * than left to each transport. It used to be each transport's job: MCP did it,
+ * the REST API did not, and `?isPrivate=true` listed private pins.
+ *
+ * `isPrivate` is not part of the input schema, so there is nothing to honour
+ * even if a caller sends it.
  */
 export function pinFilterFromInput(input: PinListInput): PinFilter {
   return {
-    isPrivate: input.isPrivate,
+    isPrivate: false,
     tag: input.tag,
     search: input.search,
     readLater: input.readLater,

--- a/libs/services/src/validation/query-coerce.ts
+++ b/libs/services/src/validation/query-coerce.ts
@@ -18,7 +18,6 @@ export const pinListQuerySchema = z.object({
     .optional()
     .describe('Filter to read-later pins only'),
   noTags: booleanFromString.optional().describe('Filter to pins with no tags'),
-  isPrivate: booleanFromString.optional().describe('Filter by private status'),
   sortBy: z.enum(['created', 'title']).optional().describe('Sort field'),
   sortDirection: z.enum(['asc', 'desc']).optional().describe('Sort direction'),
   page: numberFromString


### PR DESCRIPTION
## The problem

The two API-key surfaces disagreed about private pins.

| | list | get by id |
|---|---|---|
| **MCP** | forced `isPrivate: false` into the filter | re-checked `pin.isPrivate`, reported not-found |
| **REST** | passed the caller's `isPrivate` straight through | no check at all |

So with one API key:

- `GET /api/v1/pins?isPrivate=true` returned private pins
- `GET /api/v1/pins/{id}` returned a private pin
- the same key over MCP saw neither

Both OpenAPI descriptions already claimed otherwise — *"List public pins for the authenticated user"* and *"Returns 404 for private or non-existent pins"*. They described the MCP behavior; REST was the outlier.

The cause is structural: `AccessControl` models ownership only, so the private-pin rule was re-decided by each transport and the two drifted. `pin-query.ts` even carried a comment saying callers "should override after calling this helper" — MCP did, REST didn't.

## The fix

The rule now lives once per operation rather than once per transport:

- **`pinFilterFromInput` forces `isPrivate: false`**, and `isPrivate` is removed from both `pinListInputSchema` and `pinListQuerySchema` so there is nothing left to honor. Its only two callers are the REST API and MCP, both public-only — verified by grep, nothing else uses these helpers. The web routes have their own `parsePinQueryParams` and are untouched.
- **`PinService.getPublicPin(ac, id)`** reports a private pin as `PinNotFoundError` rather than a forbidden error, so a caller restricted to public pins cannot use the error to tell an existing private pin apart from no pin.

Both transports call the shared helpers; MCP's two inline overrides are deleted.

`GET /api/v1/tags/{id}/pins` gets the same fix for free — it went through the same helper.

## Behavior change

`?isPrivate=true` is no longer honored (the parameter is stripped by the schema), and `GET /api/v1/pins/{id}` now returns 404 for a private pin. Both match what the OpenAPI spec already documented.

## Tests

Two `api-v1` characterization tests asserted the old behavior — one named literally `it('returns private pins')`, another asserting `filter.isPrivate` was `undefined`. Given the surrounding commits are titled "characterize the …", I read those as recording what the code did rather than endorsing it. They now assert the documented behavior, with inline notes about what changed and why.

New coverage: four `getPublicPin` cases in `pin.test.ts`, and `pinFilterFromInput` tests including one that confirms it cannot be talked into `isPrivate: true`.

## Verification

| check | result |
|---|---|
| `pnpm test` | 8/8 workspaces, 778 passing |
| `pnpm typecheck` / `lint` / `format` | clean |
| `pnpm run audit` | no known vulnerabilities |

## Note

`export.tsx` still filters `!pin.isPrivate` by hand. That is a different rule — a session-authenticated user excluding private pins from their own Pinboard export, not an API-key visibility rule — so I left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)