### PR TITLE
refactor: extract PinboardService

### DIFF
--- a/apps/hono/src/lib/services.ts
+++ b/apps/hono/src/lib/services.ts
@@ -8,6 +8,7 @@ import {
   NullEmailService,
   AuthenticationService,
   MetadataService,
+  PinboardService,
   PinService,
   TagService,
   UserService,
@@ -68,12 +69,14 @@ export const accountService = new AccountService(
   emailSealer
 )
 export const pinService = new PinService(pinRepository)
+export const pinboardService = new PinboardService(pinService)
 export const tagService = new TagService(tagRepository)
 export const userService = new UserService(userRepository)
 export const apiKeyService = new ApiKeyService(apiKeyRepository)
 export const metadataService = new MetadataService(httpFetcher, htmlParser)
 
-// Export repositories for special cases
+// Still needed by the internal check-url endpoint, which looks a pin up by URL
+// without going through PinService. The Pinboard import no longer needs it.
 export { pinRepository }
 
 // Export static utilities for error handling

--- a/apps/hono/src/routes/export.test.tsx
+++ b/apps/hono/src/routes/export.test.tsx
@@ -1,0 +1,227 @@
+/**
+ * Characterization tests for the Pinboard export route.
+ *
+ * The route owns a wire format — the `hash` and `meta` md5 recipes, the
+ * timestamp shape, the hardcoded `shared: 'no'`, and the exclusion of private
+ * pins — and nothing verified any of it. These assert what it produces today,
+ * so the format survives being moved out of the handler unchanged.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+import type { MiddlewareHandler } from 'hono'
+import type { Pin } from '@pinsquirrel/domain'
+import { md5 } from '@pinsquirrel/services'
+import { testUser } from '../test-support/pin-routes'
+
+const svc = {
+  getUserPins: vi.fn(),
+}
+
+vi.mock('../lib/services', () => ({
+  pinService: {
+    getUserPins: (...a: unknown[]) => svc.getUserPins(...a) as unknown,
+  },
+}))
+
+vi.mock('../middleware/session', () => ({
+  requireAuth: (): MiddlewareHandler => async (_c, next) => {
+    await next()
+  },
+  getAuthUser: () => testUser,
+}))
+
+import { exportRoutes } from './export'
+
+function makePin(overrides: Partial<Pin> = {}): Pin {
+  return {
+    id: 'pin-1',
+    userId: testUser.id,
+    url: 'https://example.test/a',
+    title: 'Example',
+    description: null,
+    readLater: false,
+    isPrivate: false,
+    tagNames: [],
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+    ...overrides,
+  }
+}
+
+interface PinboardRow {
+  href: string
+  description: string
+  extended: string
+  meta: string
+  hash: string
+  time: string
+  shared: string
+  toread: string
+  tags: string
+}
+
+const app = new Hono()
+app.route('/export', exportRoutes)
+
+async function exportRows(): Promise<PinboardRow[]> {
+  const res = await app.request('/export/pinboard.json')
+  expect(res.status).toBe(200)
+  return (await res.json()) as PinboardRow[]
+}
+
+describe('export routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('field mapping', () => {
+    it('maps a pin onto the Pinboard shape', async () => {
+      svc.getUserPins.mockResolvedValue([
+        makePin({
+          url: 'https://example.test/a',
+          title: 'Example',
+          description: 'Notes',
+          tagNames: ['alpha', 'beta'],
+          readLater: true,
+        }),
+      ])
+
+      const [row] = await exportRows()
+
+      expect(row.href).toBe('https://example.test/a')
+      expect(row.description).toBe('Example')
+      expect(row.extended).toBe('Notes')
+      expect(row.tags).toBe('alpha beta')
+      expect(row.toread).toBe('yes')
+    })
+
+    it('maps a null description to an empty string', async () => {
+      svc.getUserPins.mockResolvedValue([makePin({ description: null })])
+
+      const [row] = await exportRows()
+
+      expect(row.extended).toBe('')
+    })
+
+    it('sets toread to no for a pin not marked read-later', async () => {
+      svc.getUserPins.mockResolvedValue([makePin({ readLater: false })])
+
+      const [row] = await exportRows()
+
+      expect(row.toread).toBe('no')
+    })
+
+    // PinSquirrel has no per-pin shared flag; every exported row says 'no'
+    // regardless of the pin, which is the inverse of what import ignores.
+    it('always reports shared as no', async () => {
+      svc.getUserPins.mockResolvedValue([makePin()])
+
+      const [row] = await exportRows()
+
+      expect(row.shared).toBe('no')
+    })
+
+    it('joins tags with spaces and yields an empty string for none', async () => {
+      svc.getUserPins.mockResolvedValue([makePin({ tagNames: [] })])
+
+      const [row] = await exportRows()
+
+      expect(row.tags).toBe('')
+    })
+  })
+
+  describe('wire format', () => {
+    it('formats the timestamp without milliseconds', async () => {
+      svc.getUserPins.mockResolvedValue([
+        makePin({ createdAt: new Date('2024-03-05T06:07:08.000Z') }),
+      ])
+
+      const [row] = await exportRows()
+
+      expect(row.time).toBe('2024-03-05T06:07:08Z')
+    })
+
+    it('hashes the URL for the hash field', async () => {
+      svc.getUserPins.mockResolvedValue([
+        makePin({ url: 'https://example.test/a' }),
+      ])
+
+      const [row] = await exportRows()
+
+      expect(row.hash).toBe(md5('https://example.test/a'))
+    })
+
+    it('hashes url, title, description, tags and readLater for meta', async () => {
+      svc.getUserPins.mockResolvedValue([
+        makePin({
+          url: 'https://example.test/a',
+          title: 'Example',
+          description: 'Notes',
+          tagNames: ['alpha', 'beta'],
+          readLater: true,
+        }),
+      ])
+
+      const [row] = await exportRows()
+
+      expect(row.meta).toBe(
+        md5(
+          [
+            'https://example.test/a',
+            'Example',
+            'Notes',
+            'alpha beta',
+            'yes',
+          ].join('\n')
+        )
+      )
+    })
+
+    it('treats a null description as an empty line in the meta hash', async () => {
+      svc.getUserPins.mockResolvedValue([
+        makePin({ url: 'u', title: 't', description: null, tagNames: [] }),
+      ])
+
+      const [row] = await exportRows()
+
+      expect(row.meta).toBe(md5(['u', 't', '', '', 'no'].join('\n')))
+    })
+  })
+
+  describe('private pins', () => {
+    it('excludes private pins from the export', async () => {
+      svc.getUserPins.mockResolvedValue([
+        makePin({ id: 'public-1', url: 'https://example.test/public' }),
+        makePin({
+          id: 'private-1',
+          url: 'https://example.test/private',
+          isPrivate: true,
+        }),
+      ])
+
+      const rows = await exportRows()
+
+      expect(rows).toHaveLength(1)
+      expect(rows[0].href).toBe('https://example.test/public')
+    })
+
+    it('returns an empty list when every pin is private', async () => {
+      svc.getUserPins.mockResolvedValue([makePin({ isPrivate: true })])
+
+      expect(await exportRows()).toEqual([])
+    })
+  })
+
+  describe('response', () => {
+    it('serves JSON as a dated attachment', async () => {
+      svc.getUserPins.mockResolvedValue([makePin()])
+
+      const res = await app.request('/export/pinboard.json')
+
+      expect(res.headers.get('content-type')).toContain('application/json')
+      expect(res.headers.get('content-disposition')).toMatch(
+        /^attachment; filename="pinsquirrel_export_\d{4}-\d{2}-\d{2}\.json"$/
+      )
+    })
+  })
+})

--- a/apps/hono/src/routes/export.test.tsx
+++ b/apps/hono/src/routes/export.test.tsx
@@ -10,17 +10,19 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { Hono } from 'hono'
 import type { MiddlewareHandler } from 'hono'
 import type { Pin } from '@pinsquirrel/domain'
-import { md5 } from '@pinsquirrel/services'
+import { PinboardService, md5, type PinService } from '@pinsquirrel/services'
 import { testUser } from '../test-support/pin-routes'
 
 const svc = {
   getUserPins: vi.fn(),
 }
 
+// A real PinboardService over a mocked PinService, so these stay end-to-end
+// assertions about the bytes the route serves.
 vi.mock('../lib/services', () => ({
-  pinService: {
+  pinboardService: new PinboardService({
     getUserPins: (...a: unknown[]) => svc.getUserPins(...a) as unknown,
-  },
+  } as unknown as PinService),
 }))
 
 vi.mock('../middleware/session', () => ({

--- a/apps/hono/src/routes/export.tsx
+++ b/apps/hono/src/routes/export.tsx
@@ -1,29 +1,7 @@
 import { Hono } from 'hono'
 import { AccessControl } from '@pinsquirrel/domain'
-import type { Pin } from '@pinsquirrel/domain'
-import { md5 } from '@pinsquirrel/services'
-import { pinService } from '../lib/services'
+import { pinboardService } from '../lib/services'
 import { getAuthUser, requireAuth } from '../middleware/session'
-
-function formatPinboardTime(date: Date): string {
-  return date.toISOString().replace('.000Z', 'Z')
-}
-
-function pinboardHash(pin: Pin): string {
-  return md5(pin.url)
-}
-
-function pinboardMeta(pin: Pin): string {
-  return md5(
-    [
-      pin.url,
-      pin.title,
-      pin.description ?? '',
-      pin.tagNames.join(' '),
-      pin.readLater ? 'yes' : 'no',
-    ].join('\n')
-  )
-}
 
 const exportRoute = new Hono()
 
@@ -34,28 +12,11 @@ exportRoute.use('*', requireAuth())
 exportRoute.get('/pinboard.json', async (c) => {
   const user = getAuthUser(c)
 
-  const ac = new AccessControl(user)
-  const allPins = await pinService.getUserPins(ac)
-
-  // Exclude private pins from export
-  const pins = allPins.filter((pin) => !pin.isPrivate)
-
-  const pinboardData = pins.map((pin) => ({
-    href: pin.url,
-    description: pin.title,
-    extended: pin.description ?? '',
-    meta: pinboardMeta(pin),
-    hash: pinboardHash(pin),
-    time: formatPinboardTime(pin.createdAt),
-    shared: 'no',
-    toread: pin.readLater ? 'yes' : 'no',
-    tags: pin.tagNames.join(' '),
-  }))
+  const pins = await pinboardService.exportPins(new AccessControl(user))
 
   const today = new Date().toISOString().split('T')[0]
-  const body = JSON.stringify(pinboardData, null, 2)
 
-  return c.body(body, 200, {
+  return c.body(JSON.stringify(pins, null, 2), 200, {
     'Content-Type': 'application/json',
     'Content-Disposition': `attachment; filename="pinsquirrel_export_${today}.json"`,
   })

--- a/apps/hono/src/routes/import.test.tsx
+++ b/apps/hono/src/routes/import.test.tsx
@@ -10,11 +10,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { Hono } from 'hono'
 import type { MiddlewareHandler } from 'hono'
 import { DuplicatePinError } from '@pinsquirrel/domain'
+import { PinboardService, type PinService } from '@pinsquirrel/services'
 import { testUser } from '../test-support/pin-routes'
 
 const svc = {
   createPin: vi.fn(),
-  updateCreatedAt: vi.fn(),
+  backdatePin: vi.fn(),
 }
 
 const session = {
@@ -22,13 +23,14 @@ const session = {
   setFlash: vi.fn(),
 }
 
+// A real PinboardService over a mocked PinService: the format rules moved into
+// the service, but these remain end-to-end assertions that the route still
+// produces the same calls and the same summary as before the extraction.
 vi.mock('../lib/services', () => ({
-  pinService: {
+  pinboardService: new PinboardService({
     createPin: (...a: unknown[]) => svc.createPin(...a) as unknown,
-  },
-  pinRepository: {
-    updateCreatedAt: (...a: unknown[]) => svc.updateCreatedAt(...a) as unknown,
-  },
+    backdatePin: (...a: unknown[]) => svc.backdatePin(...a) as unknown,
+  } as unknown as PinService),
 }))
 
 vi.mock('../middleware/session', () => ({
@@ -327,7 +329,8 @@ describe('import routes', () => {
         uploadPins([{ time: '2020-01-01T00:00:00Z' }])
       )
 
-      expect(svc.updateCreatedAt).toHaveBeenCalledWith(
+      expect(svc.backdatePin).toHaveBeenCalledWith(
+        expect.anything(),
         'pin-9',
         new Date('2020-01-01T00:00:00Z')
       )
@@ -346,7 +349,7 @@ describe('import routes', () => {
         uploadPins([{ time: '2024-06-01T00:00:00Z' }])
       )
 
-      expect(svc.updateCreatedAt).not.toHaveBeenCalled()
+      expect(svc.backdatePin).not.toHaveBeenCalled()
     })
 
     it('still counts the pin as skipped when back-dating fails', async () => {
@@ -356,7 +359,7 @@ describe('import routes', () => {
           createdAt: new Date('2024-06-01'),
         })
       )
-      svc.updateCreatedAt.mockRejectedValue(new Error('db down'))
+      svc.backdatePin.mockRejectedValue(new Error('db down'))
 
       const res = await app.request(
         '/import',

--- a/apps/hono/src/routes/import.tsx
+++ b/apps/hono/src/routes/import.tsx
@@ -1,6 +1,11 @@
 import { Hono } from 'hono'
-import { AccessControl, DuplicatePinError } from '@pinsquirrel/domain'
-import { pinService, pinRepository } from '../lib/services'
+import { AccessControl } from '@pinsquirrel/domain'
+import {
+  InvalidPinboardExportError,
+  PinboardService,
+  type InvalidPinboardExportReason,
+} from '@pinsquirrel/services'
+import { pinboardService } from '../lib/services'
 import {
   getAuthUser,
   getSessionManager,
@@ -9,16 +14,26 @@ import {
 import { ImportPage } from '../views/pages/import'
 import { logger, safeError } from '../lib/logger.js'
 
-interface PinboardPin {
-  href: string
-  description: string
-  extended: string
-  meta: string
-  hash: string
-  time: string
-  shared: string
-  toread: string
-  tags: string
+/** Uploads above this never reach the parser. */
+const MAX_UPLOAD_BYTES = 10 * 1024 * 1024
+
+const PARSE_ERRORS: Record<InvalidPinboardExportReason, string> = {
+  'malformed-json': 'Invalid JSON file format',
+  'not-a-list': 'File does not appear to be a valid Pinboard export',
+  'wrong-shape': 'File structure does not match Pinboard export format',
+}
+
+/** Describe the outcome the way the flash message has always phrased it. */
+function summarise(
+  imported: number,
+  skipped: number,
+  tagCount: number
+): string {
+  const duplicates =
+    skipped > 0
+      ? ` (skipped ${skipped} duplicate${skipped === 1 ? '' : 's'})`
+      : ''
+  return `Successfully imported ${imported} pins${duplicates} with ${tagCount} unique tags`
 }
 
 const importRoute = new Hono()
@@ -43,204 +58,74 @@ importRoute.post('/', async (c) => {
 
   const ac = new AccessControl(user)
 
+  const fail = (message: string, status?: 500) =>
+    c.html(
+      <ImportPage user={user} errors={{ _form: [message] }} />,
+      ...(status ? ([status] as const) : ([] as const))
+    )
+
   try {
-    // Parse multipart form data
     const formData = await c.req.parseBody()
     const file = formData.file
 
-    // Check if file was provided
     if (!file || !(file instanceof File)) {
-      return c.html(
-        <ImportPage
-          user={user}
-          errors={{ _form: ['Please select a file to import'] }}
-        />
-      )
+      return fail('Please select a file to import')
     }
-
-    // Validate file type
     if (!file.name.endsWith('.json')) {
-      return c.html(
-        <ImportPage
-          user={user}
-          errors={{ _form: ['Please upload a JSON file'] }}
-        />
-      )
+      return fail('Please upload a JSON file')
+    }
+    if (file.size > MAX_UPLOAD_BYTES) {
+      return fail('File size exceeds 10MB limit')
     }
 
-    // Validate file size (max 10MB)
-    const maxSize = 10 * 1024 * 1024
-    if (file.size > maxSize) {
-      return c.html(
-        <ImportPage
-          user={user}
-          errors={{ _form: ['File size exceeds 10MB limit'] }}
-        />
-      )
-    }
-
-    // Read and parse the file
-    const fileContent = await file.text()
-    let pinboardData: PinboardPin[] = []
-
+    let pins
     try {
-      pinboardData = JSON.parse(fileContent) as PinboardPin[]
-    } catch {
-      return c.html(
-        <ImportPage
-          user={user}
-          errors={{ _form: ['Invalid JSON file format'] }}
-        />
-      )
-    }
-
-    // Validate it's a Pinboard export (check for expected fields)
-    if (!Array.isArray(pinboardData) || pinboardData.length === 0) {
-      return c.html(
-        <ImportPage
-          user={user}
-          errors={{
-            _form: ['File does not appear to be a valid Pinboard export'],
-          }}
-        />
-      )
-    }
-
-    const firstPin = pinboardData[0]
-    if (!firstPin.href || !firstPin.description || !firstPin.time) {
-      return c.html(
-        <ImportPage
-          user={user}
-          errors={{
-            _form: ['File structure does not match Pinboard export format'],
-          }}
-        />
-      )
+      pins = PinboardService.parse(await file.text())
+    } catch (error) {
+      if (error instanceof InvalidPinboardExportError) {
+        return fail(PARSE_ERRORS[error.reason])
+      }
+      throw error
     }
 
     logger.info(
-      { userId: user.id, pinCount: pinboardData.length },
+      { userId: user.id, pinCount: pins.length },
       'Pinboard import started'
     )
 
-    // Import the pins
-    let importedCount = 0
-    let skippedCount = 0
-    const allTagNames = new Set<string>()
-
-    for (const pinboardPin of pinboardData) {
-      try {
-        // Parse Pinboard timestamp
-        const pinboardTimestamp = new Date(pinboardPin.time)
-
-        // Parse tags from space-separated string
-        const tagNames = pinboardPin.tags
-          .split(' ')
-          .map((tag) => tag.trim())
-          .filter((tag) => tag.length > 0)
-
-        tagNames.forEach((tag) => allTagNames.add(tag))
-
-        // Prepare title: use URL if blank, truncate if over 200 characters
-        let title = pinboardPin.description?.trim() || ''
-        if (!title) {
-          title = pinboardPin.href
-        }
-        if (title.length > 200) {
-          title = title.substring(0, 200)
-        }
-
-        // Prepare description: truncate if over 1000 characters
-        let description: string | null = pinboardPin.extended || null
-        if (description && description.length > 1000) {
-          description = description.substring(0, 1000)
-        }
-
-        // Create pin using the service with original timestamp
-        await pinService.createPin(ac, {
-          userId: user.id,
-          url: pinboardPin.href,
-          title: title,
-          description: description,
-          readLater: pinboardPin.toread === 'yes',
-          isPrivate: false,
-          tagNames: tagNames,
-          createdAt: pinboardTimestamp,
-          updatedAt: pinboardTimestamp,
-        })
-
-        importedCount++
-      } catch (error) {
-        if (error instanceof DuplicatePinError) {
-          // For duplicates, check if Pinboard timestamp is earlier
-          if (error.existingPin) {
-            try {
-              const pinboardTimestamp = new Date(pinboardPin.time)
-
-              // Update createdAt if Pinboard timestamp is earlier
-              if (pinboardTimestamp < error.existingPin.createdAt) {
-                await pinRepository.updateCreatedAt(
-                  error.existingPin.id,
-                  pinboardTimestamp
-                )
-
-                logger.debug(
-                  { userId: user.id, pinId: error.existingPin.id },
-                  'Updated createdAt for duplicate pin'
-                )
-              }
-            } catch (updateError) {
-              logger.error(
-                { userId: user.id, err: safeError(updateError) },
-                'Failed to update duplicate pin timestamp'
-              )
-            }
-          }
-
-          skippedCount++
-        } else {
-          logger.error(
-            { userId: user.id, err: safeError(error) },
-            'Failed to import pin'
-          )
-          // Continue with next pin instead of failing entire import
-        }
-      }
-    }
+    const result = await pinboardService.importPins(
+      ac,
+      user.id,
+      pins,
+      (error) =>
+        logger.error(
+          { userId: user.id, err: safeError(error) },
+          'Failed to import pin'
+        )
+    )
 
     logger.info(
       {
         userId: user.id,
-        imported: importedCount,
-        skipped: skippedCount,
-        total: pinboardData.length,
-        tags: allTagNames.size,
+        imported: result.imported,
+        skipped: result.skipped,
+        total: pins.length,
+        tags: result.tagNames.size,
       },
       'Pinboard import completed'
     )
 
-    // Build success message with skipped count if applicable
-    let successMessage = `Successfully imported ${importedCount} pins`
-    if (skippedCount > 0) {
-      successMessage += ` (skipped ${skippedCount} duplicate${skippedCount === 1 ? '' : 's'})`
-    }
-    successMessage += ` with ${allTagNames.size} unique tags`
-
-    // Set flash message and redirect to pins
-    sessionManager.setFlash('success', successMessage)
+    sessionManager.setFlash(
+      'success',
+      summarise(result.imported, result.skipped, result.tagNames.size)
+    )
     return c.redirect('/pins')
   } catch (error) {
     logger.error(
       { userId: user.id, err: safeError(error) },
       'Import failed with unexpected error'
     )
-    return c.html(
-      <ImportPage
-        user={user}
-        errors={{ _form: ['An unexpected error occurred during import'] }}
-      />,
-      500
-    )
+    return fail('An unexpected error occurred during import', 500)
   }
 })
 

--- a/libs/services/src/index.ts
+++ b/libs/services/src/index.ts
@@ -10,6 +10,13 @@ export {
 } from './services/null-email.js'
 export { MetadataService } from './services/metadata.js'
 export { PinService } from './services/pin.js'
+export {
+  PinboardService,
+  InvalidPinboardExportError,
+  type PinboardPin,
+  type ImportResult,
+  type InvalidPinboardExportReason,
+} from './services/pinboard.js'
 export { TagService } from './services/tag.js'
 export { UserService } from './services/user.js'
 export { ApiKeyService } from './services/api-key.js'

--- a/libs/services/src/services/pin.test.ts
+++ b/libs/services/src/services/pin.test.ts
@@ -23,6 +23,7 @@ describe('PinService', () => {
     findByUserId: Mock
     findByUserIdAndUrl: Mock
     countByUserId: Mock
+    updateCreatedAt: Mock
   }
 
   const mockPin: Pin = {
@@ -73,6 +74,7 @@ describe('PinService', () => {
       findByUserId: vi.fn(),
       findByUserIdAndUrl: vi.fn(),
       countByUserId: vi.fn(),
+      updateCreatedAt: vi.fn(),
     }
 
     pinService = new PinService(mockPinRepository as unknown as PinRepository)
@@ -459,6 +461,55 @@ describe('PinService', () => {
       await expect(
         pinService.getPin(createMockAccessControl(mockUser), 'pin-123')
       ).rejects.toThrow(UnauthorizedPinAccessError)
+    })
+  })
+
+  describe('backdatePin', () => {
+    it('moves an owned pin to the earlier timestamp', async () => {
+      mockPinRepository.findById.mockResolvedValue(mockPin)
+      const when = new Date('2019-05-04T00:00:00.000Z')
+
+      await pinService.backdatePin(
+        createMockAccessControl(mockUser),
+        'pin-123',
+        when
+      )
+
+      expect(mockPinRepository.updateCreatedAt).toHaveBeenCalledWith(
+        'pin-123',
+        when
+      )
+    })
+
+    it('throws PinNotFoundError if the pin does not exist', async () => {
+      mockPinRepository.findById.mockResolvedValue(null)
+
+      await expect(
+        pinService.backdatePin(
+          createMockAccessControl(mockUser),
+          'pin-123',
+          new Date()
+        )
+      ).rejects.toThrow(PinNotFoundError)
+      expect(mockPinRepository.updateCreatedAt).not.toHaveBeenCalled()
+    })
+
+    // The import loop reaches this with a pin id taken from a DuplicatePinError,
+    // so ownership is checked here rather than trusted from the caller.
+    it("refuses to backdate another user's pin", async () => {
+      mockPinRepository.findById.mockResolvedValue({
+        ...mockPin,
+        userId: 'other-user',
+      })
+
+      await expect(
+        pinService.backdatePin(
+          createMockAccessControl(mockUser),
+          'pin-123',
+          new Date()
+        )
+      ).rejects.toThrow(UnauthorizedPinAccessError)
+      expect(mockPinRepository.updateCreatedAt).not.toHaveBeenCalled()
     })
   })
 

--- a/libs/services/src/services/pin.ts
+++ b/libs/services/src/services/pin.ts
@@ -171,6 +171,31 @@ export class PinService {
   }
 
   /**
+   * Move a pin's creation date earlier.
+   *
+   * The Pinboard import uses this when it meets a URL the user already has:
+   * if the Pinboard copy is older, the existing pin keeps its original date
+   * rather than the date it happened to be saved here. Ownership is checked
+   * because the caller reaches this with an id taken from a
+   * DuplicatePinError, not from a pin it fetched itself.
+   */
+  async backdatePin(
+    ac: AccessControl,
+    pinId: string,
+    createdAt: Date
+  ): Promise<void> {
+    const pin = await this.pinRepository.findById(pinId)
+    if (!pin) {
+      throw new PinNotFoundError(pinId)
+    }
+    if (!ac.canUpdate(pin)) {
+      throw new UnauthorizedPinAccessError(pinId)
+    }
+
+    await this.pinRepository.updateCreatedAt(pinId, createdAt)
+  }
+
+  /**
    * Get a pin that the caller is allowed to see over a public-only surface.
    *
    * The REST API and the MCP server both authenticate with an API key and

--- a/libs/services/src/services/pinboard.ts
+++ b/libs/services/src/services/pinboard.ts
@@ -1,0 +1,206 @@
+import type { AccessControl, Pin } from '@pinsquirrel/domain'
+import { DuplicatePinError } from '@pinsquirrel/domain'
+import { md5 } from '../utils/crypto.js'
+import type { PinService } from './pin.js'
+
+/** One entry of a Pinboard JSON export. */
+export interface PinboardPin {
+  href: string
+  description: string
+  extended: string
+  meta: string
+  hash: string
+  time: string
+  shared: string
+  toread: string
+  tags: string
+}
+
+export type InvalidPinboardExportReason =
+  /** The file is not JSON at all. */
+  | 'malformed-json'
+  /** Valid JSON, but not a non-empty array. */
+  | 'not-a-list'
+  /** An array, but the first entry lacks the fields a Pinboard export has. */
+  | 'wrong-shape'
+
+export class InvalidPinboardExportError extends Error {
+  constructor(readonly reason: InvalidPinboardExportReason) {
+    super(`Not a valid Pinboard export: ${reason}`)
+    this.name = 'InvalidPinboardExportError'
+  }
+}
+
+export interface ImportResult {
+  imported: number
+  /** Pins already present, counted whether or not their date was corrected. */
+  skipped: number
+  /** Every distinct tag seen across the file, including on skipped pins. */
+  tagNames: Set<string>
+}
+
+/** Pinboard caps these; longer values are cut rather than rejected. */
+const MAX_TITLE = 200
+const MAX_DESCRIPTION = 1000
+
+/** Pinboard's `time` has no milliseconds. */
+function formatPinboardTime(date: Date): string {
+  return date.toISOString().replace('.000Z', 'Z')
+}
+
+/**
+ * Reading and writing the Pinboard JSON export format.
+ *
+ * The format's rules live here rather than in a route handler: the field
+ * mapping, the truncation limits, the reconciliation rule for a URL the user
+ * already has, and the `hash`/`meta` digests that make an export readable by
+ * Pinboard-compatible tools.
+ */
+export class PinboardService {
+  constructor(private readonly pinService: PinService) {}
+
+  /**
+   * Parse the text of an export file.
+   *
+   * Only the first entry is inspected. A file whose later rows are malformed
+   * still imports — those rows fail individually in `importPins` and are
+   * skipped, which is preferable to rejecting a large export outright.
+   */
+  static parse(text: string): PinboardPin[] {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(text)
+    } catch {
+      throw new InvalidPinboardExportError('malformed-json')
+    }
+
+    if (!Array.isArray(parsed) || parsed.length === 0) {
+      throw new InvalidPinboardExportError('not-a-list')
+    }
+
+    const first = parsed[0] as Partial<PinboardPin>
+    if (!first.href || !first.description || !first.time) {
+      throw new InvalidPinboardExportError('wrong-shape')
+    }
+
+    return parsed as PinboardPin[]
+  }
+
+  /**
+   * Create a pin for each entry.
+   *
+   * A single bad entry never aborts the run: a URL the user already has is
+   * counted as skipped, and any other failure is reported through `onPinError`
+   * and passed over. `shared` is ignored — imported pins all land in the main
+   * list, and privacy is managed in PinSquirrel rather than inherited.
+   */
+  async importPins(
+    ac: AccessControl,
+    userId: string,
+    pins: PinboardPin[],
+    onPinError?: (error: unknown, pin: PinboardPin) => void
+  ): Promise<ImportResult> {
+    let imported = 0
+    let skipped = 0
+    const tagNames = new Set<string>()
+
+    for (const pin of pins) {
+      const createdAt = new Date(pin.time)
+      const tags = PinboardService.parseTags(pin.tags)
+      tags.forEach(tag => tagNames.add(tag))
+
+      try {
+        await this.pinService.createPin(ac, {
+          userId,
+          url: pin.href,
+          title: PinboardService.titleFor(pin),
+          description: PinboardService.descriptionFor(pin),
+          readLater: pin.toread === 'yes',
+          isPrivate: false,
+          tagNames: tags,
+          createdAt,
+          updatedAt: createdAt,
+        })
+        imported++
+      } catch (error) {
+        if (!(error instanceof DuplicatePinError)) {
+          onPinError?.(error, pin)
+          continue
+        }
+
+        // The user already has this URL. Keep the earlier of the two dates so
+        // a pin saved here later than it was bookmarked on Pinboard does not
+        // jump to the top of the list. Best-effort: a failure to correct the
+        // date must not stop the rest of the import.
+        if (error.existingPin && createdAt < error.existingPin.createdAt) {
+          try {
+            await this.pinService.backdatePin(
+              ac,
+              error.existingPin.id,
+              createdAt
+            )
+          } catch (backdateError) {
+            onPinError?.(backdateError, pin)
+          }
+        }
+        skipped++
+      }
+    }
+
+    return { imported, skipped, tagNames }
+  }
+
+  /**
+   * Every pin the user can share, in Pinboard's shape.
+   *
+   * Private pins are left out: an export is a file that leaves the system, and
+   * nothing downstream would preserve the distinction.
+   */
+  async exportPins(ac: AccessControl): Promise<PinboardPin[]> {
+    const pins = await this.pinService.getUserPins(ac)
+    return pins
+      .filter(pin => !pin.isPrivate)
+      .map(pin => PinboardService.toPinboardPin(pin))
+  }
+
+  static toPinboardPin(pin: Pin): PinboardPin {
+    const tags = pin.tagNames.join(' ')
+    const toread = pin.readLater ? 'yes' : 'no'
+    return {
+      href: pin.url,
+      description: pin.title,
+      extended: pin.description ?? '',
+      meta: md5(
+        [pin.url, pin.title, pin.description ?? '', tags, toread].join('\n')
+      ),
+      hash: md5(pin.url),
+      time: formatPinboardTime(pin.createdAt),
+      // PinSquirrel has no per-pin shared flag, so every row reports 'no'.
+      shared: 'no',
+      toread,
+      tags,
+    }
+  }
+
+  /** Pinboard separates tags with spaces, not commas. */
+  private static parseTags(tags: string): string[] {
+    return tags
+      .split(' ')
+      .map(tag => tag.trim())
+      .filter(tag => tag.length > 0)
+  }
+
+  /** A blank title falls back to the URL, so no pin imports unlabelled. */
+  private static titleFor(pin: PinboardPin): string {
+    const title = pin.description?.trim() || pin.href
+    return title.length > MAX_TITLE ? title.substring(0, MAX_TITLE) : title
+  }
+
+  private static descriptionFor(pin: PinboardPin): string | null {
+    const description = pin.extended || null
+    if (description && description.length > MAX_DESCRIPTION) {
+      return description.substring(0, MAX_DESCRIPTION)
+    }
+    return description
+  }
+}


### PR DESCRIPTION
## Why

The Pinboard export format lived in two route handlers.

`import.tsx` carried ~180 lines of it inside a single `POST` handler: the field mapping, the 200-character title cap and 1000-character description cap, the space-separated tag split, the blank-title-falls-back-to-URL rule, and the reconciliation rule for a URL the user already has. `export.tsx` carried the other half — the `hash` and `meta` md5 recipes, the millisecond-stripped timestamp, the hardcoded `shared: 'no'`, and the private-pin exclusion.

None of that is HTTP. A `pinsquirrel import file.json` would have had to copy all of it, and the two halves of one wire format could drift apart independently.

## The seam

| stays in the route | moved to `PinboardService` |
|---|---|
| `parseBody()` multipart handling | JSON parse and shape validation |
| file present, `.json`, 10MB cap | field mapping, truncation limits, tag splitting |
| flash message, redirect | duplicate back-dating rule |
| `Content-Disposition` and filename | `hash`/`meta` digests, time format, private exclusion |

"Is this file under 10MB" is a transport concern. "Does this JSON look like a Pinboard export" is not.

Parse failures surface as `InvalidPinboardExportError` carrying a `reason` (`malformed-json` / `not-a-list` / `wrong-shape`), which the route maps back to the three user-facing strings it has always shown. `import.tsx` drops from 247 lines to ~125.

## Commits

1. **`test: characterize the Pinboard export route`** — the export had *no* tests at all, and I was about to move its wire format. 12 tests pin the md5 recipes, timestamp shape, `shared: 'no'`, and private exclusion first.
2. **`feat: add PinService.backdatePin`** — the import called `pinRepository.updateCreatedAt` directly. It now goes through the service, with the ownership check it was missing: the caller gets the pin id from a `DuplicatePinError` rather than from a pin it fetched, so nothing had verified the pin belonged to the importing user.
3. **`refactor: extract PinboardService`** — the move itself.

## On the tests

The import's 28 characterization tests from #91 were the safety net for this, and **every assertion survives unchanged**. Rather than thin them out, both route test files now have mocks that supply a *real* `PinboardService` over a mocked `PinService` — so they remain end-to-end evidence that the extraction changed nothing observable, rather than becoming assertions that one mock called another.

One assertion did change: `backdatePin(ac, id, date)` takes the `AccessControl` that `updateCreatedAt(id, date)` did not. That is a real collaborator signature change, not a behavior change.

## Verification

| check | result |
|---|---|
| `pnpm test` | 8/8 workspaces, 793 passing |
| `pnpm typecheck` / `lint` / `format` | clean |
| `pnpm run audit` | no known vulnerabilities |

## Known leftover

`lib/services.ts` still re-exports `pinRepository`. I had planned to drop it here, but `api-internal.ts:50` also uses it for the check-url lookup — one of the three different ways this codebase looks a pin up by URL. Removing the re-export belongs with consolidating those behind a `PinService.findByUrl`, not here. The comment on the re-export now says what still needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)