### PR TITLE
refactor: consolidate the duplicate-URL lookup behind PinService.findByUrl

### DIFF
--- a/apps/hono/src/lib/services.ts
+++ b/apps/hono/src/lib/services.ts
@@ -75,10 +75,6 @@ export const userService = new UserService(userRepository)
 export const apiKeyService = new ApiKeyService(apiKeyRepository)
 export const metadataService = new MetadataService(httpFetcher, htmlParser)
 
-// Still needed by the internal check-url endpoint, which looks a pin up by URL
-// without going through PinService. The Pinboard import no longer needs it.
-export { pinRepository }
-
 // Export static utilities for error handling
 export const metadataErrorUtils = {
   getHttpStatusForError: (error: Error) =>

--- a/apps/hono/src/routes/api-internal.test.tsx
+++ b/apps/hono/src/routes/api-internal.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * Characterization tests for the internal check-url endpoint.
+ *
+ * The endpoint answers the pin form's "have I already saved this?" probe, in
+ * two shapes: an HTMX fragment for the live form and JSON for anything else.
+ * Nothing verified either. These assert what it does today, before the lookup
+ * moves behind PinService.
+ *
+ * The sibling /metadata endpoint in this file remains untested — it is not in
+ * the blast radius of this change.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+import type { MiddlewareHandler } from 'hono'
+import type { Pin } from '@pinsquirrel/domain'
+import { testUser } from '../test-support/pin-routes'
+
+const svc = {
+  findByUserIdAndUrl: vi.fn(),
+}
+
+vi.mock('../lib/services', () => ({
+  metadataService: { fetchMetadata: vi.fn() },
+  metadataErrorUtils: { getUserFriendlyMessage: () => 'nope' },
+  pinRepository: {
+    findByUserIdAndUrl: (...a: unknown[]) =>
+      svc.findByUserIdAndUrl(...a) as unknown,
+  },
+}))
+
+vi.mock('../middleware/session', () => ({
+  requireAuth: (): MiddlewareHandler => async (_c, next) => {
+    await next()
+  },
+  getAuthUser: () => testUser,
+}))
+
+import { apiInternalRoutes } from './api-internal'
+
+function makePin(overrides: Partial<Pin> = {}): Pin {
+  return {
+    id: 'pin-1',
+    userId: testUser.id,
+    url: 'https://example.test/a',
+    title: 'Example',
+    description: null,
+    readLater: false,
+    isPrivate: false,
+    tagNames: [],
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+    ...overrides,
+  }
+}
+
+const app = new Hono()
+app.route('/api/internal', apiInternalRoutes)
+
+function get(query: string, htmx = false): Promise<Response> {
+  return app.request(`/api/internal/check-url${query}`, {
+    headers: htmx ? { 'HX-Request': 'true' } : {},
+  })
+}
+
+describe('GET /api/internal/check-url', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    svc.findByUserIdAndUrl.mockResolvedValue(null)
+  })
+
+  it('requires a url parameter', async () => {
+    const res = await get('')
+
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'Missing url parameter' })
+    expect(svc.findByUserIdAndUrl).not.toHaveBeenCalled()
+  })
+
+  it('looks the URL up against the signed-in user', async () => {
+    await get('?url=https://example.test/a')
+
+    expect(svc.findByUserIdAndUrl).toHaveBeenCalledWith(
+      testUser.id,
+      'https://example.test/a'
+    )
+  })
+
+  describe('JSON shape', () => {
+    it('reports a saved URL with its pin id', async () => {
+      svc.findByUserIdAndUrl.mockResolvedValue(makePin({ id: 'pin-9' }))
+
+      const res = await get('?url=https://example.test/a')
+
+      expect(await res.json()).toEqual({ exists: true, pinId: 'pin-9' })
+    })
+
+    it('reports an unsaved URL', async () => {
+      const res = await get('?url=https://example.test/new')
+
+      expect(await res.json()).toEqual({ exists: false })
+    })
+
+    // The edit form probes its own URL; without this it would report the pin
+    // being edited as a duplicate of itself.
+    it('does not count the excluded pin as a duplicate', async () => {
+      svc.findByUserIdAndUrl.mockResolvedValue(makePin({ id: 'pin-9' }))
+
+      const res = await get('?url=https://example.test/a&exclude=pin-9')
+
+      expect(await res.json()).toEqual({ exists: false })
+    })
+
+    it('still reports a different pin when excluding one', async () => {
+      svc.findByUserIdAndUrl.mockResolvedValue(makePin({ id: 'pin-9' }))
+
+      const res = await get('?url=https://example.test/a&exclude=pin-1')
+
+      expect(await res.json()).toEqual({ exists: true, pinId: 'pin-9' })
+    })
+  })
+
+  describe('HTMX shape', () => {
+    it('returns a warning fragment linking to the existing pin', async () => {
+      svc.findByUserIdAndUrl.mockResolvedValue(makePin({ id: 'pin-9' }))
+
+      const body = await (await get('?url=https://example.test/a', true)).text()
+
+      expect(body).toContain('This URL is already saved')
+      expect(body).toContain('/pins/pin-9/edit')
+      expect(body).toContain("classList.add('border-red-500')")
+    })
+
+    it('clears the warning when the URL is free', async () => {
+      const body = await (
+        await get('?url=https://example.test/new', true)
+      ).text()
+
+      expect(body).toContain("classList.remove('border-red-500')")
+      expect(body).not.toContain('already saved')
+    })
+
+    it('clears the warning for the excluded pin', async () => {
+      svc.findByUserIdAndUrl.mockResolvedValue(makePin({ id: 'pin-9' }))
+
+      const body = await (
+        await get('?url=https://example.test/a&exclude=pin-9', true)
+      ).text()
+
+      expect(body).toContain("classList.remove('border-red-500')")
+    })
+
+    // Only the literal string 'true' selects the fragment; any other value
+    // falls through to JSON.
+    it('falls back to JSON for a non-true HX-Request header', async () => {
+      const res = await app.request(
+        '/api/internal/check-url?url=https://example.test/new',
+        { headers: { 'HX-Request': 'false' } }
+      )
+
+      expect(await res.json()).toEqual({ exists: false })
+    })
+  })
+})

--- a/apps/hono/src/routes/api-internal.test.tsx
+++ b/apps/hono/src/routes/api-internal.test.tsx
@@ -12,20 +12,23 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { Hono } from 'hono'
 import type { MiddlewareHandler } from 'hono'
-import type { Pin } from '@pinsquirrel/domain'
+import type { Pin, PinRepository } from '@pinsquirrel/domain'
+import { PinService } from '@pinsquirrel/services'
 import { testUser } from '../test-support/pin-routes'
 
 const svc = {
   findByUserIdAndUrl: vi.fn(),
 }
 
+// A real PinService over a mocked repository, so the assertions below still
+// prove which query runs — not merely that one mock called another.
 vi.mock('../lib/services', () => ({
   metadataService: { fetchMetadata: vi.fn() },
   metadataErrorUtils: { getUserFriendlyMessage: () => 'nope' },
-  pinRepository: {
+  pinService: new PinService({
     findByUserIdAndUrl: (...a: unknown[]) =>
       svc.findByUserIdAndUrl(...a) as unknown,
-  },
+  } as unknown as PinRepository),
 }))
 
 vi.mock('../middleware/session', () => ({
@@ -56,8 +59,8 @@ function makePin(overrides: Partial<Pin> = {}): Pin {
 const app = new Hono()
 app.route('/api/internal', apiInternalRoutes)
 
-function get(query: string, htmx = false): Promise<Response> {
-  return app.request(`/api/internal/check-url${query}`, {
+async function get(query: string, htmx = false): Promise<Response> {
+  return await app.request(`/api/internal/check-url${query}`, {
     headers: htmx ? { 'HX-Request': 'true' } : {},
   })
 }

--- a/apps/hono/src/routes/api-internal.ts
+++ b/apps/hono/src/routes/api-internal.ts
@@ -1,8 +1,9 @@
 import { Hono } from 'hono'
+import { AccessControl } from '@pinsquirrel/domain'
 import {
   metadataService,
   metadataErrorUtils,
-  pinRepository,
+  pinService,
 } from '../lib/services'
 import { getAuthUser, requireAuth } from '../middleware/session'
 
@@ -47,7 +48,10 @@ apiInternal.get('/check-url', async (c) => {
     return c.json({ error: 'Missing url parameter' }, 400)
   }
 
-  const existingPin = await pinRepository.findByUserIdAndUrl(user.id, targetUrl)
+  const existingPin = await pinService.findByUrl(
+    new AccessControl(user),
+    targetUrl
+  )
 
   const exclude = url.searchParams.get('exclude')
   const isDuplicate = existingPin && existingPin.id !== exclude

--- a/apps/hono/src/routes/pin-routes.tsx
+++ b/apps/hono/src/routes/pin-routes.tsx
@@ -226,14 +226,10 @@ export function createPinRoutes({
       prefillTag = url.searchParams.get('tag') || ''
 
       if (prefillUrl) {
-        const existingPins = await pinService.getUserPinsWithPagination(
-          ac,
-          { url: prefillUrl },
-          { page: 1, pageSize: 1 }
-        )
+        const existing = await pinService.findByUrl(ac, prefillUrl)
 
-        if (existingPins.pins.length > 0) {
-          return c.redirect(`${baseUrl}/${existingPins.pins[0].id}/edit`)
+        if (existing) {
+          return c.redirect(`${baseUrl}/${existing.id}/edit`)
         }
       }
     }

--- a/apps/hono/src/routes/pins.test.tsx
+++ b/apps/hono/src/routes/pins.test.tsx
@@ -38,6 +38,7 @@ vi.mock('../lib/services', () => ({
     deletePin: (...a: unknown[]) => svc.deletePin(...a) as unknown,
     getUserPinsWithPagination: (...a: unknown[]) =>
       svc.getUserPinsWithPagination(...a) as unknown,
+    findByUrl: (...a: unknown[]) => svc.findByUrl(...a) as unknown,
   },
   tagService: {
     getUserTags: (...a: unknown[]) => svc.getUserTags(...a) as unknown,
@@ -163,10 +164,7 @@ describe('pins routes', () => {
     })
 
     it('prefills from query params when the URL is not already saved', async () => {
-      svc.getUserPinsWithPagination.mockResolvedValue({
-        pins: [],
-        pagination: Pagination.fromTotalCount(0),
-      })
+      svc.findByUrl.mockResolvedValue(null)
 
       const res = await app.request(
         '/pins/new?url=https%3A%2F%2Fx.test%2Fa&title=Hello&tag=foo'
@@ -181,24 +179,19 @@ describe('pins routes', () => {
     it('redirects to the existing pin when the URL is already saved', async () => {
       // Bookmarklet dedup: a prefill URL that already exists sends the user to
       // that pin's edit form instead of creating a duplicate.
-      svc.getUserPinsWithPagination.mockResolvedValue({
-        pins: [makePin({ id: 'pin-42' })],
-        pagination: Pagination.fromTotalCount(1),
-      })
+      svc.findByUrl.mockResolvedValue(makePin({ id: 'pin-42' }))
 
       const res = await app.request('/pins/new?url=https%3A%2F%2Fx.test%2Fa')
 
       expect(res.status).toBe(302)
       expect(res.headers.get('Location')).toBe('/pins/pin-42/edit')
-      expect(svc.getUserPinsWithPagination.mock.calls[0][1]).toEqual({
-        url: 'https://x.test/a',
-      })
+      expect(svc.findByUrl.mock.calls[0][1]).toBe('https://x.test/a')
     })
 
     it('skips the dedup lookup when no url param is supplied', async () => {
       await app.request('/pins/new')
 
-      expect(svc.getUserPinsWithPagination).not.toHaveBeenCalled()
+      expect(svc.findByUrl).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/hono/src/test-support/pin-routes.tsx
+++ b/apps/hono/src/test-support/pin-routes.tsx
@@ -50,6 +50,7 @@ export interface ServiceMocks {
   updatePin: Mock
   deletePin: Mock
   getUserPinsWithPagination: Mock
+  findByUrl: Mock
   getUserTags: Mock
   login: Mock
 }
@@ -61,6 +62,7 @@ export function createServiceMocks(): ServiceMocks {
     updatePin: vi.fn(),
     deletePin: vi.fn(),
     getUserPinsWithPagination: vi.fn(),
+    findByUrl: vi.fn(),
     getUserTags: vi.fn(),
     login: vi.fn(),
   }

--- a/libs/services/src/services/pin.test.ts
+++ b/libs/services/src/services/pin.test.ts
@@ -464,6 +464,46 @@ describe('PinService', () => {
     })
   })
 
+  describe('findByUrl', () => {
+    it('returns the pin the user has saved for that URL', async () => {
+      mockPinRepository.findByUserIdAndUrl.mockResolvedValue(mockPin)
+
+      const result = await pinService.findByUrl(
+        createMockAccessControl(mockUser),
+        'https://example.test/a'
+      )
+
+      expect(mockPinRepository.findByUserIdAndUrl).toHaveBeenCalledWith(
+        mockUser.id,
+        'https://example.test/a'
+      )
+      expect(result).toEqual(mockPin)
+    })
+
+    it('returns null when the user has not saved that URL', async () => {
+      mockPinRepository.findByUserIdAndUrl.mockResolvedValue(null)
+
+      const result = await pinService.findByUrl(
+        createMockAccessControl(mockUser),
+        'https://example.test/new'
+      )
+
+      expect(result).toBeNull()
+    })
+
+    // The lookup is scoped to the caller, so it cannot be used to probe
+    // whether some other account has saved a given URL.
+    it('refuses an unauthenticated caller', async () => {
+      await expect(
+        pinService.findByUrl(
+          createMockAccessControl(null),
+          'https://example.test/a'
+        )
+      ).rejects.toThrow(UnauthorizedPinAccessError)
+      expect(mockPinRepository.findByUserIdAndUrl).not.toHaveBeenCalled()
+    })
+  })
+
   describe('backdatePin', () => {
     it('moves an owned pin to the earlier timestamp', async () => {
       mockPinRepository.findById.mockResolvedValue(mockPin)

--- a/libs/services/src/services/pin.ts
+++ b/libs/services/src/services/pin.ts
@@ -49,11 +49,9 @@ export class PinService {
       throw new ValidationError(errors)
     }
 
-    // Check for duplicate URL
-    const existingPin = await this.pinRepository.findByUserIdAndUrl(
-      input.userId,
-      input.url
-    )
+    // Check for duplicate URL. canCreateAs above already established that the
+    // caller is input.userId, so the caller-scoped lookup is the same query.
+    const existingPin = await this.findByUrl(ac, input.url)
     if (existingPin) {
       throw new DuplicatePinError(input.url, {
         id: existingPin.id,
@@ -168,6 +166,24 @@ export class PinService {
       throw new UnauthorizedPinAccessError(pinId)
     }
     return pin
+  }
+
+  /**
+   * The caller's own pin for a URL, if they have one.
+   *
+   * Scoped to the authenticated user, so it cannot be used to probe whether
+   * some other account has saved a given URL. This is the one way to ask the
+   * question: it used to be asked three different ways, including one that
+   * went straight to the repository and checked nothing.
+   */
+  async findByUrl(ac: AccessControl, url: string): Promise<Pin | null> {
+    if (!ac.user) {
+      throw new UnauthorizedPinAccessError(
+        'User must be authenticated to look up pins by URL'
+      )
+    }
+
+    return this.pinRepository.findByUserIdAndUrl(ac.user.id, url)
   }
 
   /**


### PR DESCRIPTION
## The problem

Three places asked the same question — *has this user already saved this URL?* — three different ways:

| where | how |
|---|---|
| `api-internal.ts:50` | `pinRepository.findByUserIdAndUrl(user.id, url)` — **straight to the repository, no `AccessControl`** |
| `pin-routes.tsx:229` | `getUserPinsWithPagination(ac, { url }, { page: 1, pageSize: 1 })`, then check whether the array is empty |
| `PinService.createPin` | inline repository query |

The first was the one that mattered: the only route in the app reaching past the service layer to answer a question about a user's own data. It happened to pass the right user id, but nothing in the call enforced that — the authorization was a convention, not a check.

## The fix

`PinService.findByUrl(ac, url)` is now the single way to ask. It is scoped to the authenticated user and throws for an unauthenticated caller, so it cannot be used to probe whether *some other* account has saved a URL.

`createPin` routes through it as well: `canCreateAs(input.userId)` has already established that the caller *is* `input.userId` and throws otherwise, so the caller-scoped lookup is provably the same query.

**`updatePin` deliberately keeps its own.** There `input.userId` comes from the caller and ownership is checked against the *existing pin*, not against `input.userId` — so the two are equal in practice but not by construction. Switching it would be a behavior change in an edge case rather than a refactor, so I left it and it is called out in the commit.

`lib/services.ts` no longer re-exports `pinRepository`. Nothing outside the composition root touches a repository now — which is what I had wanted to do in #96 and couldn't, because this endpoint still needed it.

`pin-routes.tsx` also gets simpler: a paginated one-row query and an emptiness check become `if (existing)`.

## Tests

`check-url` had **no tests**, so I characterized it first (separate commit) — ten cases covering both response shapes and the `exclude` parameter that stops the edit form reporting a pin as a duplicate of itself.

Its mock supplies a *real* `PinService` over a mocked repository, so the assertions still prove which query runs rather than that one mock called another. The existing `findByUserIdAndUrl(testUser.id, url)` assertion therefore survives the change unedited, which is the evidence the extraction preserved behavior.

Three new `findByUrl` unit tests, including the unauthenticated case.

The sibling `/metadata` endpoint in that file remains untested — outside this change's blast radius, and noted in the test file header.

## Verification

| check | result |
|---|---|
| `pnpm test` | 8/8 workspaces, 806 passing |
| `pnpm typecheck` / `lint` / `format` | clean |
| `pnpm run audit` | no known vulnerabilities |

🤖 Generated with [Claude Code](https://claude.com/claude-code)