### PR TITLE
refactor: move the tag merge rules into TagService

### DIFF
--- a/apps/hono/src/routes/tags.test.tsx
+++ b/apps/hono/src/routes/tags.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * Characterization tests for the tag merge routes.
+ *
+ * The merge form's three validation rules live in the handler rather than in
+ * TagService, so nothing but the web form enforces them. These assert what the
+ * route does today, before those rules move into the service.
+ *
+ * GET /tags (the cloud page) is not covered here — it is untouched by that
+ * change.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+import type { MiddlewareHandler } from 'hono'
+import { makeTag, testUser } from '../test-support/pin-routes'
+
+const svc = {
+  getUserTagsWithCount: vi.fn(),
+  mergeTags: vi.fn(),
+}
+
+const session = {
+  getFlash: vi.fn(),
+  setFlash: vi.fn(),
+}
+
+vi.mock('../lib/services', () => ({
+  pinService: { getUserPinsWithPagination: vi.fn() },
+  tagService: {
+    getUserTagsWithCount: (...a: unknown[]) =>
+      svc.getUserTagsWithCount(...a) as unknown,
+    mergeTags: (...a: unknown[]) => svc.mergeTags(...a) as unknown,
+    getUserTags: vi.fn(),
+    deleteTagsWithNoPins: vi.fn(),
+  },
+}))
+
+vi.mock('../middleware/session', () => ({
+  requireAuth: (): MiddlewareHandler => async (_c, next) => {
+    await next()
+  },
+  getAuthUser: () => testUser,
+  getSessionManager: () => ({
+    getFlash: (...a: unknown[]) => session.getFlash(...a) as unknown,
+    setFlash: (...a: unknown[]) => session.setFlash(...a) as unknown,
+  }),
+}))
+
+import { tagsRoutes } from './tags'
+
+function tagWithCount(id: string, name: string, pinCount = 3) {
+  return { ...makeTag({ id, name }), pinCount }
+}
+
+const app = new Hono()
+app.route('/tags', tagsRoutes)
+
+function postMerge(fields: Record<string, string>): Promise<Response> {
+  return app.request('/tags/merge', {
+    method: 'POST',
+    body: new URLSearchParams(fields),
+  }) as Promise<Response>
+}
+
+describe('tag merge routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    session.getFlash.mockReturnValue(null)
+    svc.getUserTagsWithCount.mockResolvedValue([
+      tagWithCount('tag-a', 'alpha'),
+      tagWithCount('tag-b', 'beta'),
+      tagWithCount('tag-c', 'gamma'),
+    ])
+  })
+
+  describe('GET /tags/merge', () => {
+    it('lists only tags that have pins', async () => {
+      svc.getUserTagsWithCount.mockResolvedValue([
+        tagWithCount('tag-a', 'alpha', 3),
+        tagWithCount('tag-empty', 'unused', 0),
+      ])
+
+      const res = await app.request('/tags/merge')
+      const html = await res.text()
+
+      expect(res.status).toBe(200)
+      expect(html).toContain('alpha')
+      expect(html).not.toContain('unused')
+    })
+  })
+
+  describe('POST /tags/merge validation', () => {
+    it('rejects a merge with no source tags', async () => {
+      const res = await postMerge({ destinationTagId: 'tag-c' })
+
+      expect(await res.text()).toContain(
+        'Please select at least one source tag.'
+      )
+      expect(svc.mergeTags).not.toHaveBeenCalled()
+    })
+
+    it('rejects a merge with no destination tag', async () => {
+      const res = await postMerge({ sourceTagIds: 'tag-a,tag-b' })
+
+      expect(await res.text()).toContain('Please select a destination tag.')
+      expect(svc.mergeTags).not.toHaveBeenCalled()
+    })
+
+    // Merging a tag into itself would delete it and reassign its pins to
+    // nothing, so the destination must be distinct from every source.
+    it('rejects a destination that is also a source', async () => {
+      const res = await postMerge({
+        sourceTagIds: 'tag-a,tag-c',
+        destinationTagId: 'tag-c',
+      })
+
+      expect(await res.text()).toContain(
+        'Destination tag cannot be one of the source tags.'
+      )
+      expect(svc.mergeTags).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('POST /tags/merge success', () => {
+    it('merges the selected sources into the destination', async () => {
+      svc.mergeTags.mockResolvedValue(undefined)
+
+      const res = await postMerge({
+        sourceTagIds: 'tag-a,tag-b',
+        destinationTagId: 'tag-c',
+      })
+
+      expect(svc.mergeTags).toHaveBeenCalledWith(
+        expect.anything(),
+        ['tag-a', 'tag-b'],
+        'tag-c'
+      )
+      expect(res.status).toBe(302)
+      expect(res.headers.get('Location')).toBe('/tags')
+      expect(session.setFlash).toHaveBeenCalledWith(
+        'success',
+        'Tags merged successfully!'
+      )
+    })
+
+    // The hidden input carries the selection as one comma-separated value.
+    it('splits the comma-separated source list', async () => {
+      svc.mergeTags.mockResolvedValue(undefined)
+
+      await postMerge({
+        sourceTagIds: 'tag-a,tag-b',
+        destinationTagId: 'tag-c',
+      })
+
+      expect(svc.mergeTags.mock.calls[0][1]).toEqual(['tag-a', 'tag-b'])
+    })
+
+    it('accepts a single source tag', async () => {
+      svc.mergeTags.mockResolvedValue(undefined)
+
+      await postMerge({ sourceTagIds: 'tag-a', destinationTagId: 'tag-c' })
+
+      expect(svc.mergeTags.mock.calls[0][1]).toEqual(['tag-a'])
+    })
+  })
+
+  describe('POST /tags/merge failure', () => {
+    it('re-renders with an error when the merge throws', async () => {
+      svc.mergeTags.mockRejectedValue(new Error('db down'))
+
+      const res = await postMerge({
+        sourceTagIds: 'tag-a',
+        destinationTagId: 'tag-c',
+      })
+
+      expect(res.status).toBe(500)
+      expect(await res.text()).toContain(
+        'Failed to merge tags. Please try again.'
+      )
+    })
+  })
+})

--- a/apps/hono/src/routes/tags.test.tsx
+++ b/apps/hono/src/routes/tags.test.tsx
@@ -11,11 +11,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { Hono } from 'hono'
 import type { MiddlewareHandler } from 'hono'
+import type { TagRepository } from '@pinsquirrel/domain'
+import { TagService } from '@pinsquirrel/services'
 import { makeTag, testUser } from '../test-support/pin-routes'
 
-const svc = {
-  getUserTagsWithCount: vi.fn(),
+const repo = {
+  findById: vi.fn(),
+  findByUserIdWithPinCount: vi.fn(),
   mergeTags: vi.fn(),
+  deleteTagsWithNoPins: vi.fn(),
 }
 
 const session = {
@@ -23,15 +27,19 @@ const session = {
   setFlash: vi.fn(),
 }
 
+// A real TagService over a mocked repository. The merge rules moved into the
+// service, so mocking the service wholesale would stop these tests exercising
+// the very thing they exist to pin down.
 vi.mock('../lib/services', () => ({
   pinService: { getUserPinsWithPagination: vi.fn() },
-  tagService: {
-    getUserTagsWithCount: (...a: unknown[]) =>
-      svc.getUserTagsWithCount(...a) as unknown,
-    mergeTags: (...a: unknown[]) => svc.mergeTags(...a) as unknown,
-    getUserTags: vi.fn(),
-    deleteTagsWithNoPins: vi.fn(),
-  },
+  tagService: new TagService({
+    findById: (...a: unknown[]) => repo.findById(...a) as unknown,
+    findByUserIdWithPinCount: (...a: unknown[]) =>
+      repo.findByUserIdWithPinCount(...a) as unknown,
+    mergeTags: (...a: unknown[]) => repo.mergeTags(...a) as unknown,
+    deleteTagsWithNoPins: (...a: unknown[]) =>
+      repo.deleteTagsWithNoPins(...a) as unknown,
+  } as unknown as TagRepository),
 }))
 
 vi.mock('../middleware/session', () => ({
@@ -65,16 +73,20 @@ describe('tag merge routes', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     session.getFlash.mockReturnValue(null)
-    svc.getUserTagsWithCount.mockResolvedValue([
+    repo.findByUserIdWithPinCount.mockResolvedValue([
       tagWithCount('tag-a', 'alpha'),
       tagWithCount('tag-b', 'beta'),
       tagWithCount('tag-c', 'gamma'),
     ])
+    // Ownership lookups inside mergeTags.
+    repo.findById.mockImplementation((id: string) =>
+      Promise.resolve(makeTag({ id, name: id }))
+    )
   })
 
   describe('GET /tags/merge', () => {
     it('lists only tags that have pins', async () => {
-      svc.getUserTagsWithCount.mockResolvedValue([
+      repo.findByUserIdWithPinCount.mockResolvedValue([
         tagWithCount('tag-a', 'alpha', 3),
         tagWithCount('tag-empty', 'unused', 0),
       ])
@@ -95,14 +107,14 @@ describe('tag merge routes', () => {
       expect(await res.text()).toContain(
         'Please select at least one source tag.'
       )
-      expect(svc.mergeTags).not.toHaveBeenCalled()
+      expect(repo.mergeTags).not.toHaveBeenCalled()
     })
 
     it('rejects a merge with no destination tag', async () => {
       const res = await postMerge({ sourceTagIds: 'tag-a,tag-b' })
 
       expect(await res.text()).toContain('Please select a destination tag.')
-      expect(svc.mergeTags).not.toHaveBeenCalled()
+      expect(repo.mergeTags).not.toHaveBeenCalled()
     })
 
     // Merging a tag into itself would delete it and reassign its pins to
@@ -116,21 +128,21 @@ describe('tag merge routes', () => {
       expect(await res.text()).toContain(
         'Destination tag cannot be one of the source tags.'
       )
-      expect(svc.mergeTags).not.toHaveBeenCalled()
+      expect(repo.mergeTags).not.toHaveBeenCalled()
     })
   })
 
   describe('POST /tags/merge success', () => {
     it('merges the selected sources into the destination', async () => {
-      svc.mergeTags.mockResolvedValue(undefined)
+      repo.mergeTags.mockResolvedValue(undefined)
 
       const res = await postMerge({
         sourceTagIds: 'tag-a,tag-b',
         destinationTagId: 'tag-c',
       })
 
-      expect(svc.mergeTags).toHaveBeenCalledWith(
-        expect.anything(),
+      expect(repo.mergeTags).toHaveBeenCalledWith(
+        testUser.id,
         ['tag-a', 'tag-b'],
         'tag-c'
       )
@@ -144,28 +156,28 @@ describe('tag merge routes', () => {
 
     // The hidden input carries the selection as one comma-separated value.
     it('splits the comma-separated source list', async () => {
-      svc.mergeTags.mockResolvedValue(undefined)
+      repo.mergeTags.mockResolvedValue(undefined)
 
       await postMerge({
         sourceTagIds: 'tag-a,tag-b',
         destinationTagId: 'tag-c',
       })
 
-      expect(svc.mergeTags.mock.calls[0][1]).toEqual(['tag-a', 'tag-b'])
+      expect(repo.mergeTags.mock.calls[0][1]).toEqual(['tag-a', 'tag-b'])
     })
 
     it('accepts a single source tag', async () => {
-      svc.mergeTags.mockResolvedValue(undefined)
+      repo.mergeTags.mockResolvedValue(undefined)
 
       await postMerge({ sourceTagIds: 'tag-a', destinationTagId: 'tag-c' })
 
-      expect(svc.mergeTags.mock.calls[0][1]).toEqual(['tag-a'])
+      expect(repo.mergeTags.mock.calls[0][1]).toEqual(['tag-a'])
     })
   })
 
   describe('POST /tags/merge failure', () => {
     it('re-renders with an error when the merge throws', async () => {
-      svc.mergeTags.mockRejectedValue(new Error('db down'))
+      repo.mergeTags.mockRejectedValue(new Error('db down'))
 
       const res = await postMerge({
         sourceTagIds: 'tag-a',

--- a/apps/hono/src/routes/tags.tsx
+++ b/apps/hono/src/routes/tags.tsx
@@ -1,5 +1,5 @@
 import { Hono } from 'hono'
-import { AccessControl } from '@pinsquirrel/domain'
+import { AccessControl, ValidationError } from '@pinsquirrel/domain'
 import { pinService, tagService } from '../lib/services'
 import { getString } from '../lib/form'
 import {
@@ -111,63 +111,29 @@ tags.post('/merge', async (c) => {
   const userTags = await tagService.getUserTagsWithCount(ac, user.id)
   const tagsWithPins = userTags.filter((tag) => tag.pinCount > 0)
 
-  // Validation
-  if (sourceTagIds.length === 0) {
-    return c.html(
+  const reject = (errors: Record<string, string[]>, status?: 500) =>
+    c.html(
       <TagMergePage
         user={user}
         tags={tagsWithPins}
-        errors={{ _form: ['Please select at least one source tag.'] }}
-        selectedSourceTags={sourceTagIds}
-        selectedDestinationTag={destinationTagId}
-      />
-    )
-  }
-
-  if (!destinationTagId) {
-    return c.html(
-      <TagMergePage
-        user={user}
-        tags={tagsWithPins}
-        errors={{ _form: ['Please select a destination tag.'] }}
-        selectedSourceTags={sourceTagIds}
-        selectedDestinationTag={destinationTagId}
-      />
-    )
-  }
-
-  if (sourceTagIds.includes(destinationTagId)) {
-    return c.html(
-      <TagMergePage
-        user={user}
-        tags={tagsWithPins}
-        errors={{
-          _form: ['Destination tag cannot be one of the source tags.'],
-        }}
-        selectedSourceTags={sourceTagIds}
-        selectedDestinationTag={destinationTagId}
-      />
-    )
-  }
-
-  try {
-    // Perform the merge
-    await tagService.mergeTags(ac, sourceTagIds, destinationTagId)
-
-    // Redirect with success message
-    sessionManager.setFlash('success', 'Tags merged successfully!')
-    return c.redirect('/tags')
-  } catch {
-    return c.html(
-      <TagMergePage
-        user={user}
-        tags={tagsWithPins}
-        errors={{ _form: ['Failed to merge tags. Please try again.'] }}
+        errors={errors}
         selectedSourceTags={sourceTagIds}
         selectedDestinationTag={destinationTagId}
       />,
-      500
+      ...(status ? ([status] as const) : ([] as const))
     )
+
+  try {
+    // The selection rules live in TagService, so every caller gets them.
+    await tagService.mergeTags(ac, sourceTagIds, destinationTagId)
+
+    sessionManager.setFlash('success', 'Tags merged successfully!')
+    return c.redirect('/tags')
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      return reject(error.fields)
+    }
+    return reject({ _form: ['Failed to merge tags. Please try again.'] }, 500)
   }
 })
 

--- a/apps/hono/src/views/pages/tag-merge.tsx
+++ b/apps/hono/src/views/pages/tag-merge.tsx
@@ -24,7 +24,9 @@ export function TagMergePage({
   selectedSourceTags = [],
   selectedDestinationTag = '',
 }: TagMergePageProps) {
-  const formError = errors?._form?.[0]
+  // Fall back to any field the service reported: mergeTags keys its errors by
+  // input name (sourceTagIds / destinationTagId), not by the _form convention.
+  const formError = errors?._form?.[0] ?? Object.values(errors ?? {})[0]?.[0]
 
   return (
     <DefaultLayout

--- a/libs/services/src/services/tag.test.ts
+++ b/libs/services/src/services/tag.test.ts
@@ -351,11 +351,62 @@ describe('TagService.mergeTags', () => {
   })
 
   it('merges under the caller’s id, not an id supplied by the request', async () => {
-    vi.mocked(mockRepo.findById).mockResolvedValue(targetTag)
+    vi.mocked(mockRepo.findById).mockImplementation((id: string) =>
+      Promise.resolve({ target: targetTag, 'src-a': sourceA }[id] ?? null)
+    )
 
-    await service.mergeTags(new AccessControl(owner), [], 'target')
+    await service.mergeTags(new AccessControl(owner), ['src-a'], 'target')
 
-    expect(mockRepo.mergeTags).toHaveBeenCalledWith('owner-id', [], 'target')
+    expect(mockRepo.mergeTags).toHaveBeenCalledWith(
+      'owner-id',
+      ['src-a'],
+      'target'
+    )
+  })
+
+  describe('input validation', () => {
+    // These three rules were enforced by the web form's handler, so nothing
+    // else calling mergeTags — a CLI, a future API — was covered by them.
+    it('rejects an empty source list', async () => {
+      await expect(
+        service.mergeTags(new AccessControl(owner), [], 'target')
+      ).rejects.toBeInstanceOf(ValidationError)
+      expect(mockRepo.mergeTags).not.toHaveBeenCalled()
+    })
+
+    it('rejects a blank destination', async () => {
+      await expect(
+        service.mergeTags(new AccessControl(owner), ['src-a'], '')
+      ).rejects.toBeInstanceOf(ValidationError)
+      expect(mockRepo.mergeTags).not.toHaveBeenCalled()
+    })
+
+    // Merging a tag into itself would delete it and strand its pins.
+    it('rejects a destination that is also a source', async () => {
+      await expect(
+        service.mergeTags(
+          new AccessControl(owner),
+          ['src-a', 'target'],
+          'target'
+        )
+      ).rejects.toBeInstanceOf(ValidationError)
+      expect(mockRepo.mergeTags).not.toHaveBeenCalled()
+    })
+
+    it('validates before touching the repository at all', async () => {
+      await expect(
+        service.mergeTags(new AccessControl(owner), [], 'target')
+      ).rejects.toBeInstanceOf(ValidationError)
+      expect(mockRepo.findById).not.toHaveBeenCalled()
+    })
+
+    it('reports the offending field', async () => {
+      await expect(
+        service.mergeTags(new AccessControl(owner), [], 'target')
+      ).rejects.toMatchObject({
+        fields: { sourceTagIds: ['Please select at least one source tag.'] },
+      })
+    })
   })
 })
 

--- a/libs/services/src/services/tag.ts
+++ b/libs/services/src/services/tag.ts
@@ -102,6 +102,25 @@ export class TagService {
       )
     }
 
+    // These three rules used to live in the web form's handler, so nothing
+    // else calling mergeTags was covered by them. Checked before any lookup so
+    // an invalid request costs no queries.
+    const errors: Record<string, string[]> = {}
+    if (sourceTagIds.length === 0) {
+      errors.sourceTagIds = ['Please select at least one source tag.']
+    }
+    if (!targetTagId) {
+      errors.destinationTagId = ['Please select a destination tag.']
+    } else if (sourceTagIds.includes(targetTagId)) {
+      // Merging a tag into itself would delete it and strand its pins.
+      errors.destinationTagId = [
+        'Destination tag cannot be one of the source tags.',
+      ]
+    }
+    if (Object.keys(errors).length > 0) {
+      throw new ValidationError(errors)
+    }
+
     // Verify the target tag belongs to the user
     const targetTag = await this.tagRepository.findById(targetTagId)
     if (!targetTag) {


### PR DESCRIPTION
## The problem

Three rules lived in `routes/tags.tsx`, the web form's handler:

- at least one source tag
- a destination tag
- a destination distinct from every source

`TagService.mergeTags` checked ownership and nothing else. So any caller that isn't the web form — a CLI, a future API endpoint — could merge a tag into itself, which deletes it and strands its pins. The rules were enforced by the shape of the form, not by the operation.

## The fix

`mergeTags` now validates before touching the repository, so an invalid request costs no queries. The messages are unchanged.

They are keyed by input name (`sourceTagIds` / `destinationTagId`) rather than the app's `_form` convention, since a service shouldn't know a view's error-slot naming. `TagMergePage` reads `errors._form?.[0] ?? Object.values(errors)[0]?.[0]`, so any service-thrown `ValidationError` renders without the route translating field names.

The route's three near-identical validation blocks collapse into a `ValidationError` catch, and its two remaining error paths share one `reject()` helper.

## Tests

`routes/tags.tsx` had **no tests**, so I characterized the merge routes first (separate commit) — 8 cases covering all three rules, the comma-separated source parsing, the success redirect and flash, and the failure re-render.

Those tests now run a **real `TagService` over a mocked `TagRepository`**. Mocking the service wholesale would have meant the validation they exist to pin down never ran — the tests would have passed against a version with the rules deleted. Assertions moved from `tagService.mergeTags` to `repository.mergeTags` accordingly.

**One existing service test changed.** `merges under the caller's id, not an id supplied by the request` passed `[]` as its source list — incidental to its actual assertion, which is that the merge runs under `ac.user.id`. An empty list is now invalid, so it passes `['src-a']` instead. Its point is intact.

Five new service tests cover the rules directly, including that validation happens before any repository call.

`GET /tags` (the tag cloud) is untouched and remains uncovered — noted in the test file header.

## Verification

| check | result |
|---|---|
| `pnpm test` | 8/8 workspaces, 819 passing |
| `pnpm typecheck` / `lint` / `format` | clean |
| `pnpm run audit` | no known vulnerabilities |

🤖 Generated with [Claude Code](https://claude.com/claude-code)