### PR TITLE
refactor: collapse AccountService's three email lookups into one helper

### DIFF
--- a/libs/services/src/services/account.test.ts
+++ b/libs/services/src/services/account.test.ts
@@ -483,33 +483,6 @@ describe('AccountService', () => {
     })
   })
 
-  describe('findByEmail', () => {
-    it('should find user by email', async () => {
-      vi.mocked(mockUserRepository.findByEmailHash).mockResolvedValue(mockUser)
-
-      const result = await accountService.findByEmail('test@example.com')
-
-      expect(mockUserRepository.findByEmailHash).toHaveBeenCalledWith(
-        'hashed_test@example.com'
-      )
-      expect(result).toEqual(mockUser)
-    })
-
-    it('should return null when user not found', async () => {
-      vi.mocked(mockUserRepository.findByEmailHash).mockResolvedValue(null)
-
-      const result = await accountService.findByEmail('nonexistent@example.com')
-
-      expect(result).toBeNull()
-    })
-
-    it('should throw validation error for invalid email', async () => {
-      await expect(accountService.findByEmail('invalid-email')).rejects.toThrow(
-        'Invalid email'
-      )
-    })
-  })
-
   describe('requestPasswordReset', () => {
     it('should create a password reset token and send email', async () => {
       const mockUserWithEmail = {

--- a/libs/services/src/services/account.ts
+++ b/libs/services/src/services/account.ts
@@ -76,9 +76,7 @@ export class AccountService {
     const existingUserByUsername = await this.userRepository.findByUsername(
       input.username
     )
-    const emailHash = hashEmail(input.email)
-    const existingUserByEmail =
-      await this.userRepository.findByEmailHash(emailHash)
+    const existingUserByEmail = await this.findUserByEmail(input.email)
 
     // Handle conflicts without revealing which field conflicted
     if (existingUserByEmail) {
@@ -122,7 +120,9 @@ export class AccountService {
     const user = await this.userRepository.create({
       username: input.username,
       passwordHash: null, // No password yet - they'll set it via email verification
-      emailHash,
+      // Hashed here rather than reusing a binding from the duplicate check:
+      // this is the stored value, and the lookup above hides its own hashing.
+      emailHash: hashEmail(input.email),
       emailEncrypted,
     })
 
@@ -194,20 +194,6 @@ export class AccountService {
     })
   }
 
-  async findByEmail(email: string): Promise<User | null> {
-    // Validate email at service boundary
-    const emailResult = emailSchema.safeParse(email)
-    if (!emailResult.success) {
-      throw new ValidationError({
-        email: [emailResult.error.issues[0]?.message || 'Invalid email'],
-      })
-    }
-
-    // Hash the email in the business logic layer
-    const emailHash = hashEmail(email)
-    return await this.userRepository.findByEmailHash(emailHash)
-  }
-
   async requestPasswordReset(input: {
     email: string
     resetUrl: string
@@ -220,9 +206,7 @@ export class AccountService {
       })
     }
 
-    // Hash the email to find the user
-    const emailHash = hashEmail(input.email)
-    const user = await this.userRepository.findByEmailHash(emailHash)
+    const user = await this.findUserByEmail(input.email)
 
     // Don't reveal whether the email exists or not for security
     if (!user) {
@@ -345,5 +329,19 @@ export class AccountService {
 
     // Check if token is valid (not expired)
     return await this.passwordResetRepository.isValidToken(tokenHash)
+  }
+
+  /**
+   * The account registered with this address, if any.
+   *
+   * Emails are never stored in the clear, so every lookup has to go through
+   * the same hash. This was written out at each of the three call sites, one
+   * of which was a public findByEmail that nothing called.
+   *
+   * Validation is the caller's business: both callers validate at their own
+   * boundary, and register does so well before it gets here.
+   */
+  private async findUserByEmail(email: string): Promise<User | null> {
+    return this.userRepository.findByEmailHash(hashEmail(email))
   }
 }


### PR DESCRIPTION
This is the leftover I flagged when splitting `AccountService` out of `AuthenticationService` (#94) and again in #96 — closing it now.

## The duplication

"Hash the address, then look the user up by that hash" appeared three times:

| site | what it did |
|---|---|
| `register` | duplicate-email check before creating the account |
| `requestPasswordReset` | find the account to send a reset link to |
| `findByEmail` (public) | validate, hash, look up — **no callers anywhere** |

The third is the interesting one. It wasn't dead weight so much as the extracted version of a pattern the other two never adopted: a public method whose behavior was written out inline twice beside it.

## What changed

`findUserByEmail` is now the one path. `findByEmail` is **deleted** rather than kept as unused API surface — nothing outside its own tests referenced it, and it isn't exported from the barrel. If a caller ever wants it back it's three lines, and its behavior is exercised through both methods that now use the helper.

Validation stays with the callers. Both already validate the address at their own boundary, and `register` does so well before it reaches the lookup, so folding validation into the helper would have meant validating twice in every path.

## Two things deliberately left alone

**`register` still hashes separately for the value it stores.** It needs the hash as a column value, not just as a query, so the two derivations are intentional and now sit at their points of use — one is a lookup, one is a write. Typecheck caught this when I first removed the shared binding.

**`updateEmail`'s `hashEmail` call is untouched.** It hashes for writing, not for looking anything up, so it isn't part of this pattern despite matching on grep.

## Verification

| check | result |
|---|---|
| `pnpm test` | 8/8 workspaces, 803 passing |
| `pnpm typecheck` / `lint` / `format` | clean |
| `pnpm run audit` | no known vulnerabilities |

Services drops 266 → 263 tests: exactly the three that covered the deleted method. No production behavior is uncovered by that — `register` and `requestPasswordReset` exercise the same path through the helper.

Independent of #98; the two touch different files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)