### PR TITLE
refactor: let ApiKeyService resolve the principal behind a token

### DIFF
--- a/apps/hono/src/lib/services.ts
+++ b/apps/hono/src/lib/services.ts
@@ -72,7 +72,7 @@ export const pinService = new PinService(pinRepository)
 export const pinboardService = new PinboardService(pinService)
 export const tagService = new TagService(tagRepository)
 export const userService = new UserService(userRepository)
-export const apiKeyService = new ApiKeyService(apiKeyRepository)
+export const apiKeyService = new ApiKeyService(apiKeyRepository, userRepository)
 export const metadataService = new MetadataService(httpFetcher, htmlParser)
 
 // Export static utilities for error handling

--- a/apps/hono/src/middleware/bearer-auth.ts
+++ b/apps/hono/src/middleware/bearer-auth.ts
@@ -1,7 +1,6 @@
 import type { Context } from 'hono'
 import type { ApiKey, User } from '@pinsquirrel/domain'
 import { apiKeyService } from '../lib/services.js'
-import { userRepository } from '../lib/db.js'
 
 export interface AuthenticatedRequest {
   user: User
@@ -13,7 +12,6 @@ export type AuthFailure =
   | { reason: 'missing'; message: 'Missing API key' }
   | { reason: 'invalid'; message: 'Invalid API key' }
   | { reason: 'invalid_header'; message: 'Invalid Authorization header' }
-  | { reason: 'no_user'; message: 'User not found' }
 
 function extractRawKey(
   c: Context,
@@ -42,10 +40,10 @@ function extractRawKey(
 /**
  * Authenticate a request via API key (Bearer token, optionally `X-API-Key`).
  *
- * Returns the resolved `User` and `ApiKey` on success, or a structured
- * `AuthFailure` describing what went wrong. Callers (REST middleware,
- * MCP middleware) decide how to render the failure as an HTTP response
- * and what context variables to set on success.
+ * Header parsing stays here because it is transport; resolving the token to a
+ * principal is ApiKeyService's job. Callers (REST middleware, MCP middleware)
+ * decide how to render the failure as an HTTP response and what context
+ * variables to set on success.
  */
 export async function authenticateBearer(
   c: Context,
@@ -56,21 +54,19 @@ export async function authenticateBearer(
   const extracted = extractRawKey(c, options)
   if ('failure' in extracted) return { ok: false, failure: extracted.failure }
 
-  const apiKey = await apiKeyService.authenticateByKey(extracted.rawKey)
-  if (!apiKey) {
+  // One call: the service resolves the key and the account behind it. A key
+  // whose owner has gone is reported as invalid rather than as a missing user,
+  // so the response never confirms that the key itself was good.
+  const authenticated = await apiKeyService.authenticate(extracted.rawKey)
+  if (!authenticated) {
     return {
       ok: false,
       failure: { reason: 'invalid', message: 'Invalid API key' },
     }
   }
 
-  const user = await userRepository.findById(apiKey.userId)
-  if (!user) {
-    return {
-      ok: false,
-      failure: { reason: 'no_user', message: 'User not found' },
-    }
+  return {
+    ok: true,
+    auth: { ...authenticated, rawKey: extracted.rawKey },
   }
-
-  return { ok: true, auth: { user, apiKey, rawKey: extracted.rawKey } }
 }

--- a/apps/hono/src/routes/api-v1.test.ts
+++ b/apps/hono/src/routes/api-v1.test.ts
@@ -7,8 +7,7 @@ import {
   TagNotFoundError,
 } from '@pinsquirrel/domain'
 
-const mockAuthenticateByKey = vi.fn()
-const mockFindUserById = vi.fn()
+const mockAuthenticate = vi.fn()
 const mockGetPin = vi.fn()
 const mockGetPublicPin = vi.fn()
 const mockGetUserPinsWithPagination = vi.fn()
@@ -18,8 +17,7 @@ const mockGetUserTagById = vi.fn()
 
 vi.mock('../lib/services', () => ({
   apiKeyService: {
-    authenticateByKey: (...args: unknown[]) =>
-      mockAuthenticateByKey(...args) as unknown,
+    authenticate: (...args: unknown[]) => mockAuthenticate(...args) as unknown,
   },
   pinService: {
     getPin: (...args: unknown[]) => mockGetPin(...args) as unknown,
@@ -33,12 +31,6 @@ vi.mock('../lib/services', () => ({
       mockGetUserTagsWithCount(...args) as unknown,
     getUserTagById: (...args: unknown[]) =>
       mockGetUserTagById(...args) as unknown,
-  },
-}))
-
-vi.mock('../lib/db', () => ({
-  userRepository: {
-    findById: (...args: unknown[]) => mockFindUserById(...args) as unknown,
   },
 }))
 
@@ -110,7 +102,7 @@ describe('api-v1 routes', () => {
     })
 
     it('returns 401 with invalid API key', async () => {
-      mockAuthenticateByKey.mockResolvedValue(null)
+      mockAuthenticate.mockResolvedValue(null)
       const res = await app.request('/api/v1/pins', {
         headers: { Authorization: 'Bearer ps_bad' },
       })
@@ -118,19 +110,23 @@ describe('api-v1 routes', () => {
       expect(await res.json()).toEqual({ error: 'Invalid API key' })
     })
 
-    it('returns 401 when user lookup fails', async () => {
-      mockAuthenticateByKey.mockResolvedValue(testApiKey)
-      mockFindUserById.mockResolvedValue(null)
+    // Keys cascade-delete with their user, so a key with no owner is only
+    // reachable in a race. It reports as invalid rather than confirming the
+    // key itself was good.
+    it('returns 401 when the key has no owner', async () => {
+      mockAuthenticate.mockResolvedValue(null)
       const res = await app.request('/api/v1/pins', {
         headers: { Authorization: 'Bearer ps_ok' },
       })
       expect(res.status).toBe(401)
-      expect(await res.json()).toEqual({ error: 'User not found' })
+      expect(await res.json()).toEqual({ error: 'Invalid API key' })
     })
 
     it('accepts X-API-Key header', async () => {
-      mockAuthenticateByKey.mockResolvedValue(testApiKey)
-      mockFindUserById.mockResolvedValue(testUser)
+      mockAuthenticate.mockResolvedValue({
+        apiKey: testApiKey,
+        user: testUser,
+      })
       mockGetUserPinsWithPagination.mockResolvedValue({
         pins: [],
         pagination: Pagination.fromTotalCount(0),
@@ -144,8 +140,10 @@ describe('api-v1 routes', () => {
 
   describe('GET /api/v1/pins', () => {
     beforeEach(() => {
-      mockAuthenticateByKey.mockResolvedValue(testApiKey)
-      mockFindUserById.mockResolvedValue(testUser)
+      mockAuthenticate.mockResolvedValue({
+        apiKey: testApiKey,
+        user: testUser,
+      })
     })
 
     it('returns pins and pagination shape', async () => {
@@ -203,8 +201,10 @@ describe('api-v1 routes', () => {
 
   describe('GET /api/v1/pins/:id', () => {
     beforeEach(() => {
-      mockAuthenticateByKey.mockResolvedValue(testApiKey)
-      mockFindUserById.mockResolvedValue(testUser)
+      mockAuthenticate.mockResolvedValue({
+        apiKey: testApiKey,
+        user: testUser,
+      })
     })
 
     it('returns pin', async () => {
@@ -230,8 +230,10 @@ describe('api-v1 routes', () => {
 
   describe('GET /api/v1/tags', () => {
     beforeEach(() => {
-      mockAuthenticateByKey.mockResolvedValue(testApiKey)
-      mockFindUserById.mockResolvedValue(testUser)
+      mockAuthenticate.mockResolvedValue({
+        apiKey: testApiKey,
+        user: testUser,
+      })
     })
 
     it('returns tags', async () => {
@@ -259,8 +261,10 @@ describe('api-v1 routes', () => {
 
   describe('GET /api/v1/tags/:id/pins', () => {
     beforeEach(() => {
-      mockAuthenticateByKey.mockResolvedValue(testApiKey)
-      mockFindUserById.mockResolvedValue(testUser)
+      mockAuthenticate.mockResolvedValue({
+        apiKey: testApiKey,
+        user: testUser,
+      })
     })
 
     it('returns pins filtered by tag name', async () => {

--- a/libs/services/src/services/api-key.test.ts
+++ b/libs/services/src/services/api-key.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { ApiKeyService } from './api-key.js'
-import type { ApiKeyRepository, ApiKey, User } from '@pinsquirrel/domain'
+import type {
+  ApiKeyRepository,
+  ApiKey,
+  User,
+  UserRepository,
+} from '@pinsquirrel/domain'
 import {
   AccessControl,
   ApiKeyNotFoundError,
@@ -19,6 +24,7 @@ vi.mock('../utils/crypto.js', () => ({
 describe('ApiKeyService', () => {
   let service: ApiKeyService
   let mockRepo: ApiKeyRepository
+  let mockUserRepo: UserRepository
 
   const userId = '123e4567-e89b-12d3-a456-426614174000'
 
@@ -67,7 +73,18 @@ describe('ApiKeyService', () => {
       updateLastUsed: vi.fn(),
       delete: vi.fn(),
     }
-    service = new ApiKeyService(mockRepo)
+    mockUserRepo = {
+      findById: vi.fn(),
+      findByEmailHash: vi.fn(),
+      findByUsername: vi.fn(),
+      findByStatus: vi.fn(),
+      findAll: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      addRole: vi.fn(),
+    }
+    service = new ApiKeyService(mockRepo, mockUserRepo)
   })
 
   describe('createApiKey', () => {
@@ -173,6 +190,58 @@ describe('ApiKeyService', () => {
       await expect(service.revokeApiKey(ac, 'key-1')).rejects.toThrow(
         UnauthorizedApiKeyAccessError
       )
+    })
+  })
+
+  describe('authenticate', () => {
+    it('returns the key and its owner for a usable key', async () => {
+      vi.mocked(mockRepo.findByKeyHash).mockResolvedValue(mockApiKey)
+      vi.mocked(mockUserRepo.findById).mockResolvedValue(mockUser)
+
+      const result = await service.authenticate('ps_mock-secure-token')
+
+      expect(result).toEqual({ apiKey: mockApiKey, user: mockUser })
+      expect(mockUserRepo.findById).toHaveBeenCalledWith(userId)
+    })
+
+    it('records the key as used', async () => {
+      vi.mocked(mockRepo.findByKeyHash).mockResolvedValue(mockApiKey)
+      vi.mocked(mockUserRepo.findById).mockResolvedValue(mockUser)
+
+      await service.authenticate('ps_mock-secure-token')
+
+      expect(mockRepo.updateLastUsed).toHaveBeenCalled()
+    })
+
+    it('returns null for an unknown key', async () => {
+      vi.mocked(mockRepo.findByKeyHash).mockResolvedValue(null)
+
+      await expect(service.authenticate('ps_unknown-key')).resolves.toBeNull()
+      expect(mockUserRepo.findById).not.toHaveBeenCalled()
+    })
+
+    it('returns null for an expired key', async () => {
+      vi.mocked(mockRepo.findByKeyHash).mockResolvedValue({
+        ...mockApiKey,
+        expiresAt: new Date('2020-01-01'),
+      })
+
+      await expect(
+        service.authenticate('ps_mock-secure-token')
+      ).resolves.toBeNull()
+      expect(mockUserRepo.findById).not.toHaveBeenCalled()
+    })
+
+    // Keys cascade-delete with their user, so this is only reachable in the
+    // race between reading the key and the row going away. It reads as an
+    // invalid key rather than confirming the key was good.
+    it('returns null when the owner has gone', async () => {
+      vi.mocked(mockRepo.findByKeyHash).mockResolvedValue(mockApiKey)
+      vi.mocked(mockUserRepo.findById).mockResolvedValue(null)
+
+      await expect(
+        service.authenticate('ps_mock-secure-token')
+      ).resolves.toBeNull()
     })
   })
 

--- a/libs/services/src/services/api-key.ts
+++ b/libs/services/src/services/api-key.ts
@@ -2,6 +2,8 @@ import type {
   AccessControl,
   ApiKey,
   ApiKeyRepository,
+  User,
+  UserRepository,
 } from '@pinsquirrel/domain'
 import {
   ApiKeyLimitExceededError,
@@ -15,7 +17,10 @@ import { apiKeyNameSchema } from '../validation/api-key.js'
 const MAX_KEYS_PER_USER = 5
 
 export class ApiKeyService {
-  constructor(private readonly apiKeyRepository: ApiKeyRepository) {}
+  constructor(
+    private readonly apiKeyRepository: ApiKeyRepository,
+    private readonly userRepository: UserRepository
+  ) {}
 
   async createApiKey(
     ac: AccessControl,
@@ -79,6 +84,34 @@ export class ApiKeyService {
     }
 
     await this.apiKeyRepository.delete(keyId)
+  }
+
+  /**
+   * Resolve a raw bearer token to the key and the account behind it.
+   *
+   * One operation rather than two: the transport used to authenticate the key
+   * here and then look the user up against the repository itself, which is the
+   * one place an API request resolved its own principal without going through
+   * a service.
+   *
+   * A key whose owner has gone reads as an unknown key. That is only reachable
+   * in the race between reading the key and the row cascading away, and a
+   * distinct answer would confirm the key itself was good.
+   */
+  async authenticate(
+    rawKey: string
+  ): Promise<{ apiKey: ApiKey; user: User } | null> {
+    const apiKey = await this.authenticateByKey(rawKey)
+    if (!apiKey) {
+      return null
+    }
+
+    const user = await this.userRepository.findById(apiKey.userId)
+    if (!user) {
+      return null
+    }
+
+    return { apiKey, user }
   }
 
   async authenticateByKey(rawKey: string): Promise<ApiKey | null> {


### PR DESCRIPTION
Second of the direct-repository-call sites from #97's incorrect claim. One left after this.

## The problem

`bearer-auth.ts` authenticated the key through the service, then resolved the user itself:

```ts
const apiKey = await apiKeyService.authenticateByKey(rawKey)   // service
const user = await userRepository.findById(apiKey.userId)      // repository
```

So every API and MCP request resolved its own principal half inside the service layer and half outside it — the operation "authenticate this bearer token" was split across a service call and a raw repository read that the app stitched together.

## The fix

`ApiKeyService.authenticate(rawKey)` returns `{ apiKey, user } | null` and owns the whole operation. The service gains `userRepository`, which its other methods don't need but this one genuinely does.

The middleware keeps header parsing — `Authorization: Bearer` vs `X-API-Key`, and the `allowApiKeyHeader` option that lets MCP refuse the latter. That is transport and belongs there. It no longer imports `lib/db` at all.

`authenticateByKey` is retained and still tested; `authenticate` composes it.

## Behaviour change

A key whose owner has gone now reports **`Invalid API key`** instead of **`User not found`**, and the `AuthFailure` union loses its `no_user` case.

Two reasons this is the right trade, both worth checking:

`api_keys.user_id` is declared `onDelete: 'cascade'` (`schema/api-keys.ts:8`), so deleting a user removes their keys. The branch was only reachable in the race between reading the key row and it cascading away — not a state the schema lets you rest in.

And a distinct answer confirmed to the caller that the key itself was valid, which is information a failed request shouldn't carry.

`api-v1.test.ts` had a test named `returns 401 when user lookup fails` asserting `'User not found'`. It is now `returns 401 when the key has no owner` asserting `'Invalid API key'`, with the reasoning inline.

## Tests

Five new service tests for `authenticate`: the happy path, that the key is recorded as used, unknown key, expired key, and vanished owner. The last two assert the user lookup is skipped entirely.

The route test's `apiKeyService.authenticateByKey` + `lib/db` mocks collapse into one `authenticate` mock, and the `vi.mock('../lib/db', ...)` block is deleted — which is itself the evidence the middleware stopped reaching for a repository.

## Verification

| check | result |
|---|---|
| `pnpm test` | 8/8 workspaces, 827 passing |
| `pnpm typecheck` / `lint` / `format` | clean |
| `pnpm run audit` | no known vulnerabilities |

## What's left

`middleware/session.ts` — the last one, and the substantial one. It uses `sessionRepository` for six operations plus a `userRepository.findById`, and it also holds real policy: the 30-day vs 24-hour session durations, the 15-minute private-unlock window, and the flash read-and-clear semantics. That needs a decision about whether session lifetime belongs in a service, so I would rather agree the shape before writing it.

`routes/health.ts` uses the raw `db` handle for a liveness probe. I would leave that alone — it isn't domain logic and doesn't want a service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)