### PR TITLE
docs: state the layering rule and its two deliberate exceptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,21 @@ pnpm monorepo orchestrated with Turbo:
 
 Workspace packages depend on each other via the `workspace:*` protocol, e.g. `"@pinsquirrel/domain": "workspace:*"`.
 
+### Layering
+
+**Apps assemble and call services. Services use repositories. Apps do not call repositories.**
+
+`libs/services` is the only layer that enforces `AccessControl` and validation, so a repository call from an app is an authorization check that did not happen. Every instance of this has produced a real bug: the REST API listed private pins because it re-decided the rule a transport at a time, the internal check-url endpoint looked pins up with no `AccessControl` at all, and the tag merge rules were enforced by the shape of a form rather than by the operation.
+
+A route or middleware that wants data should call a service method. If none fits, add one — that is the cheaper half of the work.
+
+Two deliberate exceptions, both documented at the point of use:
+
+- `apps/hono/src/middleware/session.ts` — a session is how an `AccessControl` gets built, so there is nothing for a service to check, and only this app could ever call it.
+- `apps/hono/src/routes/health.ts` — asks whether the connection is alive, which no service models.
+
+Composition roots (`apps/hono/src/lib/db.ts`, `apps/admin/src/runtime.ts`) construct repositories by definition; that is their job.
+
 ## Essential Commands
 
 Root-level (Turbo orchestrates across packages):

--- a/apps/hono/src/middleware/session.ts
+++ b/apps/hono/src/middleware/session.ts
@@ -1,3 +1,27 @@
+/**
+ * Cookie-backed sessions.
+ *
+ * This file talks to the repositories directly, which nothing else outside the
+ * composition root does. That is deliberate, not an oversight.
+ *
+ * Everywhere else, an app calling a repository skips the layer that enforces
+ * authorization and validation — that is what let the REST API list private
+ * pins, and what let the tag merge rules be enforced by a form instead of the
+ * operation. None of that applies here: a session is how an AccessControl gets
+ * built in the first place, so there is no authorization to bypass and nothing
+ * for a service to check. A SessionService would take no AccessControl, and
+ * only this app could ever call it — the admin app keeps its sessions in
+ * memory, and an API key or a CLI has no session at all.
+ *
+ * So the persistence stays here, alongside the parts that are unambiguously
+ * web-only: the cookie itself, the flash message that survives one redirect,
+ * and the private-unlock window. The equivalent for API callers does live in a
+ * service — ApiKeyService.authenticate — because a token resolves to a
+ * principal the same way for every transport.
+ *
+ * If sessions ever need to be readable from outside this app, that is the
+ * point to revisit this.
+ */
 import type { Context, MiddlewareHandler } from 'hono'
 import { getCookie, setCookie, deleteCookie } from 'hono/cookie'
 import type { Session, User } from '@pinsquirrel/domain'

--- a/apps/hono/src/routes/health.ts
+++ b/apps/hono/src/routes/health.ts
@@ -3,6 +3,9 @@ import { sql } from 'drizzle-orm'
 import { db } from '../lib/db.js'
 import { logger, safeError } from '../lib/logger.js'
 
+// Uses the raw client rather than a service on purpose: this asks whether the
+// connection is alive, which is infrastructure rather than anything a service
+// models. See middleware/session.ts for the other deliberate exception.
 const healthRoutes = new Hono()
 
 healthRoutes.get('/', async (c) => {


### PR DESCRIPTION
Documentation only — no code changes, no behaviour change.

## Why

#95, #97, #98, #100 and #101 all enforced the same rule, and it was written down nowhere. Meanwhile the two places that legitimately break it read as oversights rather than decisions — which is how they'd get "fixed" by someone tidying up, or cited as precedent by someone adding a third.

## What

**`CLAUDE.md`** gains a short *Layering* section under Repository Structure: apps assemble and call services, services use repositories, apps don't call repositories. It says why — `libs/services` is the only layer enforcing `AccessControl` and validation — and cites the three bugs that came from breaking it, so the rule reads as load-bearing rather than stylistic. It also notes that composition roots construct repositories by definition.

**`middleware/session.ts`** explains itself: a session is how an `AccessControl` gets *built*, so there is nothing for a service to check and no `AccessControl` to bypass. A `SessionService` would take no `AccessControl` and only this app could ever call it — the admin app keeps sessions in memory, and an API key or a CLI has none. The contrast worth having on record is that the equivalent for API callers *does* live in a service (`ApiKeyService.authenticate`, #101), because a token resolves to a principal the same way for every transport.

It also names what stays alongside the persistence — the cookie, the flash message, the private-unlock window — as unambiguously web-only, and says when to revisit: if sessions ever need to be readable from outside this app.

**`routes/health.ts`** gets three lines: it uses the raw client to ask whether the connection is alive, which no service models.

## Why documenting rather than refactoring

I designed the `SessionService` and recommended against building it. The rule exists to protect authorization and validation invariants; sessions have neither, so the bug class behind the other five PRs cannot occur here. Against that, `session.ts` is the best-tested file in the app — 26 tests over 648 lines — and auth-critical, and the refactor would move every one of those tests from mocking `lib/db` to mocking `lib/services` for no behavioural gain and no new capability.

Consistency was the only argument for it, and a comment buys that more cheaply than a refactor of the login path.

## Note

The `CLAUDE.md` section is slightly beyond "document the exception" — an exception to an unstated rule is half a thought, so I stated the rule too. Easy to drop that file from the diff if you'd rather keep CLAUDE.md as-is.

## Verification

| check | result |
|---|---|
| `pnpm test` | 8/8 workspaces, 827 passing |
| `pnpm typecheck` / `lint` / `format` | clean |
| `pnpm run audit` | no known vulnerabilities |

🤖 Generated with [Claude Code](https://claude.com/claude-code)