### PR TITLE
refactor: move package internals out of the composition root

### DIFF
--- a/apps/hono/src/lib/db.ts
+++ b/apps/hono/src/lib/db.ts
@@ -1,12 +1,4 @@
-import {
-  createDatabaseClient,
-  DrizzleApiKeyRepository,
-  DrizzlePasswordResetRepository,
-  DrizzlePinRepository,
-  DrizzleSessionRepository,
-  DrizzleTagRepository,
-  DrizzleUserRepository,
-} from '@pinsquirrel/database'
+import { createDatabaseClient, createRepositories } from '@pinsquirrel/database'
 import type { MySql2Database } from 'drizzle-orm/mysql2'
 
 // Create database client
@@ -14,10 +6,12 @@ export const db: MySql2Database = createDatabaseClient(
   process.env.DATABASE_URL || 'mysql://localhost:3306/pinsquirrel'
 )
 
-// Create repository instances
-export const userRepository = new DrizzleUserRepository(db)
-export const tagRepository = new DrizzleTagRepository(db)
-export const pinRepository = new DrizzlePinRepository(db, tagRepository)
-export const passwordResetRepository = new DrizzlePasswordResetRepository(db)
-export const sessionRepository = new DrizzleSessionRepository(db)
-export const apiKeyRepository = new DrizzleApiKeyRepository(db)
+// How the repositories compose is the database package's business, not ours.
+export const {
+  userRepository,
+  tagRepository,
+  pinRepository,
+  passwordResetRepository,
+  sessionRepository,
+  apiKeyRepository,
+} = createRepositories(db)

--- a/apps/hono/src/lib/services.ts
+++ b/apps/hono/src/lib/services.ts
@@ -1,5 +1,5 @@
 import { CheerioHtmlParser, NodeHttpFetcher } from '@pinsquirrel/adapters'
-import { sealEmail, assertValidPublicKey } from '@pinsquirrel/crypto'
+import { createEmailSealer } from '@pinsquirrel/crypto'
 import type { EmailService } from '@pinsquirrel/domain'
 import { MailgunEmailService } from '@pinsquirrel/mailgun'
 import {
@@ -40,15 +40,14 @@ const emailService: EmailService =
       })
     : new NullEmailService()
 
-// Create email sealer if a public key is configured. This lets the waitlist be
-// contacted later via the offline admin app; this server can never decrypt it.
-// Validate the key at boot so a bad EMAIL_PUBLIC_KEY fails fast here instead of
-// returning runtime 500s the first time an auth flow tries to seal an email.
+// Seal waitlist emails if a public key is configured, so they can be contacted
+// later via the offline admin app; this server can never decrypt them. The
+// sealer validates the key on construction, so a bad EMAIL_PUBLIC_KEY fails at
+// boot rather than the first time an auth flow tries to seal an address.
 let emailSealer: EmailSealer | undefined
 if (process.env.EMAIL_PUBLIC_KEY) {
-  const publicKey = process.env.EMAIL_PUBLIC_KEY
   try {
-    assertValidPublicKey(publicKey)
+    emailSealer = createEmailSealer(process.env.EMAIL_PUBLIC_KEY)
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error)
     throw new Error(
@@ -57,7 +56,6 @@ if (process.env.EMAIL_PUBLIC_KEY) {
       { cause: error }
     )
   }
-  emailSealer = { seal: (email: string) => sealEmail(email, publicKey) }
 }
 
 // Create service instances

--- a/libs/crypto/src/email-crypto.test.ts
+++ b/libs/crypto/src/email-crypto.test.ts
@@ -4,6 +4,7 @@ import {
   sealEmail,
   openSealedEmail,
   assertValidPublicKey,
+  createEmailSealer,
 } from './email-crypto.js'
 
 describe('email sealing', () => {
@@ -49,5 +50,34 @@ describe('assertValidPublicKey', () => {
   it('rejects a private key pasted in place of a public key', async () => {
     const { privateKey } = await generateKeyPair()
     expect(() => assertValidPublicKey(privateKey)).toThrow()
+  })
+})
+
+describe('createEmailSealer', () => {
+  it('returns a sealer whose output the keypair can open', async () => {
+    const { publicKey, privateKey } = await generateKeyPair()
+    const sealer = createEmailSealer(publicKey)
+
+    const sealed = await sealer.seal('person@example.com')
+
+    await expect(openSealedEmail(sealed, privateKey)).resolves.toBe(
+      'person@example.com'
+    )
+  })
+
+  // Validating on construction is the point: a bad key fails where it is
+  // configured rather than the first time an email needs sealing.
+  it('rejects an invalid public key immediately', () => {
+    expect(() => createEmailSealer('not-a-key')).toThrow(/X25519 public key/)
+  })
+
+  it('rejects an empty public key immediately', () => {
+    expect(() => createEmailSealer('')).toThrow(/X25519 public key/)
+  })
+
+  it('rejects a private key pasted in place of a public key', async () => {
+    const { privateKey } = await generateKeyPair()
+
+    expect(() => createEmailSealer(privateKey)).toThrow(/X25519 public key/)
   })
 })

--- a/libs/crypto/src/email-crypto.ts
+++ b/libs/crypto/src/email-crypto.ts
@@ -152,3 +152,21 @@ export async function openSealedEmail(
   ])
   return plaintext.toString('utf8')
 }
+
+/**
+ * A sealer bound to one public key, validated up front.
+ *
+ * Validating on construction means a bad key fails where it is configured
+ * rather than the first time an account needs its address sealed. The returned
+ * shape matches the `EmailSealer` that services expect, without this package
+ * having to depend on them for the type.
+ */
+export function createEmailSealer(publicKeyB64: string): {
+  seal(email: string): Promise<string>
+} {
+  assertValidPublicKey(publicKeyB64)
+
+  return {
+    seal: (email: string) => sealEmail(email, publicKeyB64),
+  }
+}

--- a/libs/crypto/src/index.ts
+++ b/libs/crypto/src/index.ts
@@ -4,6 +4,7 @@ export {
   sealEmail,
   openSealedEmail,
   assertValidPublicKey,
+  createEmailSealer,
 } from './email-crypto.js'
 export {
   serializeRawPrivateKey,

--- a/libs/database/src/create-repositories.test.ts
+++ b/libs/database/src/create-repositories.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import type { MySql2Database } from 'drizzle-orm/mysql2'
+import { createRepositories } from './create-repositories.js'
+import { DrizzleApiKeyRepository } from './repositories/api-key.js'
+import { DrizzlePasswordResetRepository } from './repositories/password-reset.js'
+import { DrizzlePinRepository } from './repositories/pin.js'
+import { DrizzleSessionRepository } from './repositories/session.js'
+import { DrizzleTagRepository } from './repositories/tag.js'
+import { DrizzleUserRepository } from './repositories/user.js'
+
+// The constructors only store their arguments, so wiring can be checked
+// without a database.
+const db = {} as MySql2Database
+
+describe('createRepositories', () => {
+  it('returns every repository the app needs', () => {
+    const repos = createRepositories(db)
+
+    expect(repos.userRepository).toBeInstanceOf(DrizzleUserRepository)
+    expect(repos.tagRepository).toBeInstanceOf(DrizzleTagRepository)
+    expect(repos.pinRepository).toBeInstanceOf(DrizzlePinRepository)
+    expect(repos.passwordResetRepository).toBeInstanceOf(
+      DrizzlePasswordResetRepository
+    )
+    expect(repos.sessionRepository).toBeInstanceOf(DrizzleSessionRepository)
+    expect(repos.apiKeyRepository).toBeInstanceOf(DrizzleApiKeyRepository)
+  })
+
+  // The whole point of the factory: the pin repository composes the tag
+  // repository, and no consumer should have to know that to wire it up.
+  it('gives the pin repository the same tag repository it returns', () => {
+    const repos = createRepositories(db)
+
+    const composed = (
+      repos.pinRepository as unknown as { tagRepository: unknown }
+    ).tagRepository
+
+    expect(composed).toBe(repos.tagRepository)
+  })
+})

--- a/libs/database/src/create-repositories.ts
+++ b/libs/database/src/create-repositories.ts
@@ -1,0 +1,48 @@
+import type { MySql2Database } from 'drizzle-orm/mysql2'
+import type {
+  ApiKeyRepository,
+  PasswordResetRepository,
+  PinRepository,
+  SessionRepository,
+  TagRepository,
+  UserRepository,
+} from '@pinsquirrel/domain'
+import { DrizzleApiKeyRepository } from './repositories/api-key.js'
+import { DrizzlePasswordResetRepository } from './repositories/password-reset.js'
+import { DrizzlePinRepository } from './repositories/pin.js'
+import { DrizzleSessionRepository } from './repositories/session.js'
+import { DrizzleTagRepository } from './repositories/tag.js'
+import { DrizzleUserRepository } from './repositories/user.js'
+
+export interface Repositories {
+  userRepository: UserRepository
+  tagRepository: TagRepository
+  pinRepository: PinRepository
+  passwordResetRepository: PasswordResetRepository
+  sessionRepository: SessionRepository
+  apiKeyRepository: ApiKeyRepository
+}
+
+/**
+ * Every repository, wired to one database client.
+ *
+ * The individual classes stay exported for tests and for consumers that need
+ * only one of them. This exists so nothing outside the package has to know how
+ * they compose — the pin repository takes the tag repository, and a consumer
+ * assembling them by hand has to know that and keep knowing it. Growing a
+ * second such dependency should change this file and nothing else.
+ */
+export function createRepositories(db: MySql2Database): Repositories {
+  const tagRepository = new DrizzleTagRepository(db)
+
+  return {
+    userRepository: new DrizzleUserRepository(db),
+    tagRepository,
+    // Reads and writes pins by tag name, so it resolves names through the
+    // same tag repository returned above rather than a second instance.
+    pinRepository: new DrizzlePinRepository(db, tagRepository),
+    passwordResetRepository: new DrizzlePasswordResetRepository(db),
+    sessionRepository: new DrizzleSessionRepository(db),
+    apiKeyRepository: new DrizzleApiKeyRepository(db),
+  }
+}

--- a/libs/database/src/index.ts
+++ b/libs/database/src/index.ts
@@ -1,6 +1,9 @@
 // Re-export drizzle as createDatabaseClient for stable API
 export { drizzle as createDatabaseClient } from 'drizzle-orm/mysql2'
 
+// Wired repository set — the usual way to build them
+export { createRepositories, type Repositories } from './create-repositories.js'
+
 // Repository implementations
 export { DrizzleUserRepository } from './repositories/user.js'
 export { DrizzlePinRepository } from './repositories/pin.js'


### PR DESCRIPTION
The last two structural items. Two commits, independent of each other.

## 1. `createRepositories` in `libs/database`

`apps/hono/src/lib/db.ts` built six repositories by hand, which meant it had to know that `DrizzlePinRepository` takes a tag repository:

```ts
const tagRepository = new DrizzleTagRepository(db)
const pinRepository = new DrizzlePinRepository(db, tagRepository)
```

That's an internal fact about how the package composes, not a wiring choice a consumer should make — and a second such dependency would have to be learned by every consumer at once. The composition root should be choosing *implementations and config*, not reproducing a graph.

`createRepositories(db)` owns it. The individual classes stay exported for tests and for consumers that need only one.

**`apps/admin` deliberately keeps `new DrizzleUserRepository(db)`.** It needs exactly one repository, and that one takes nothing but the client, so the knowledge this factory hides doesn't apply. Forcing the full set on it would contradict the partial-assembly argument — a consumer shouldn't have to construct five things it will never call.

## 2. `createEmailSealer` in `libs/crypto`

`lib/services.ts` carried eighteen lines that validated `EMAIL_PUBLIC_KEY`, built an inline `{ seal }` adapter over `sealEmail`, and translated the validation failure. That's policy about how the sealing key is handled, sitting in what should be wiring.

`createEmailSealer(publicKey)` validates on construction, so a bad key still fails at boot rather than at the first seal. The app keeps only what it alone knows: the environment variable's name, and that `keygen` is how you make one.

Its return type is structural (`{ seal(email: string): Promise<string> }`) rather than the `EmailSealer` interface from `libs/services`, so `crypto` stays dependency-free.

## Two things worth knowing

**Three of the four new crypto tests initially passed against no implementation at all.** A bare `expect(() => createEmailSealer(x)).toThrow()` is satisfied by `TypeError: createEmailSealer is not a function`, so they went green before anything existed. They now assert `/X25519 public key/` and fail properly without the implementation. Worth remembering for any `toThrow()` on a function that might not exist yet.

**`libs/database`'s 164 tests need a live MySQL** — its vitest `globalSetup` connects on 3306. My earlier local `pnpm quality` runs were replaying them from Turbo's cache rather than executing them; CI has always run them for real. I started the dev container and ran them properly for this change: 164 pass, including the 2 new ones. Flagging it because "N tests passing" from a local run does not mean that package's suite actually executed.

## Verification

| check | result |
|---|---|
| `pnpm test` | 8/8 workspaces, 833 passing (database executed against real MySQL, not cached) |
| `pnpm typecheck` / `lint` / `format` | clean |
| `pnpm run audit` | no known vulnerabilities |

🤖 Generated with [Claude Code](https://claude.com/claude-code)