### PR TITLE
fix: close three brute-force gaps around password checks

### DIFF
--- a/apps/hono/src/middleware/rate-limit.test.ts
+++ b/apps/hono/src/middleware/rate-limit.test.ts
@@ -34,7 +34,19 @@ describe('getClientIp', () => {
     expect(await res.text()).toBe('10.0.0.1')
   })
 
-  it('returns unknown when no headers present', async () => {
+  it('falls back to the socket peer address when no headers present', async () => {
+    // Without a proxy header there is nothing to key a rate limit on, and the
+    // old 'unknown' literal put every such caller in one shared bucket - so a
+    // single attacker could 429 everyone else. The socket address is always
+    // available under @hono/node-server, so this branch is what runs in
+    // production whenever a request arrives without going through the proxy.
+    const res = await app.request('/test', undefined, {
+      incoming: { socket: { remoteAddress: '9.9.9.9' } },
+    })
+    expect(await res.text()).toBe('9.9.9.9')
+  })
+
+  it('returns unknown only when even the socket address is unavailable', async () => {
     const res = await app.request('/test')
     expect(await res.text()).toBe('unknown')
   })

--- a/apps/hono/src/middleware/rate-limit.ts
+++ b/apps/hono/src/middleware/rate-limit.ts
@@ -1,16 +1,51 @@
 import type { Context, MiddlewareHandler } from 'hono'
+import { getConnInfo } from '@hono/node-server/conninfo'
 import { RateLimiter } from './rate-limiter'
+
+// getConnInfo reaches into c.env.incoming.socket, which only exists when the
+// request came through the Node server. Under app.request() in tests, and in
+// any other non-Node context, it throws rather than returning undefined.
+function socketAddress(c: Context): string | undefined {
+  try {
+    return getConnInfo(c).remote.address
+  } catch {
+    return undefined
+  }
+}
 
 export function getClientIp(c: Context): string {
   const xff = c.req.header('x-forwarded-for')
   if (xff) {
+    // The last entry, not the first: a single trusted proxy appends the peer
+    // it actually received from, so anything earlier is client-supplied and
+    // spoofable.
     const parts = xff.split(',')
     return parts[parts.length - 1].trim()
   }
-  return c.req.header('x-real-ip') ?? 'unknown'
+  // No proxy header means the request did not come through the reverse proxy.
+  // Falling back to the socket peer keeps each such caller in its own bucket;
+  // a single shared literal here would let one attacker exhaust the limit for
+  // everyone else at once.
+  return c.req.header('x-real-ip') ?? socketAddress(c) ?? 'unknown'
 }
 
 export const signinLimiter = new RateLimiter({
+  maxAttempts: 5,
+  windowMs: 15 * 60 * 1000,
+})
+
+// Keyed on the address alone, so it still counts when the attacker rotates
+// usernames. Deliberately far looser than signinLimiter: a shared office NAT
+// or CGNAT puts real users behind one address, and this must not trip for them.
+export const signinIpLimiter = new RateLimiter({
+  maxAttempts: 20,
+  windowMs: 15 * 60 * 1000,
+})
+
+// Keyed on the user id rather than the address: unlocking requires an
+// authenticated session, so whoever is guessing already holds the cookie and
+// their IP proves nothing - rotating it must not buy them a fresh budget.
+export const privateUnlockLimiter = new RateLimiter({
   maxAttempts: 5,
   windowMs: 15 * 60 * 1000,
 })

--- a/apps/hono/src/routes/auth.test.tsx
+++ b/apps/hono/src/routes/auth.test.tsx
@@ -44,6 +44,9 @@ const limiter = {
   hit: vi.fn(),
   reset: vi.fn(),
   ipLimited: vi.fn(),
+  ipIsLimited: vi.fn(),
+  ipHit: vi.fn(),
+  ipReset: vi.fn(),
 }
 
 vi.mock('../lib/services', () => ({
@@ -80,9 +83,16 @@ vi.mock('../middleware/rate-limit', () => ({
     hit: (...a: unknown[]): unknown => limiter.hit(...a) as unknown,
     reset: (...a: unknown[]): unknown => limiter.reset(...a) as unknown,
   },
+  signinIpLimiter: {
+    isLimited: (...a: unknown[]): boolean =>
+      limiter.ipIsLimited(...a) as boolean,
+    hit: (...a: unknown[]): unknown => limiter.ipHit(...a) as unknown,
+    reset: (...a: unknown[]): unknown => limiter.ipReset(...a) as unknown,
+  },
   signupLimiter: {},
   forgotPasswordLimiter: {},
   signinRateLimitKey: (_c: unknown, username: string) => `ip:${username}`,
+  getClientIp: () => 'ip',
   rateLimitByIp: (): MiddlewareHandler => async (c, next) => {
     if (limiter.ipLimited() as boolean) return c.text('Too many requests', 429)
     await next()
@@ -113,6 +123,7 @@ describe('auth routes', () => {
     session.getFlash.mockReturnValue(null)
     limiter.isLimited.mockReturnValue(false)
     limiter.ipLimited.mockReturnValue(false)
+    limiter.ipIsLimited.mockReturnValue(false)
     app = new Hono()
     app.route('/', authRoutes)
   })
@@ -255,6 +266,62 @@ describe('auth routes', () => {
         await app.request('/signin', form({ username: 'alice', password: 'x' }))
 
         expect(limiter.hit).not.toHaveBeenCalled()
+      })
+
+      // The IP:username key stops guessing at one account but never fires
+      // against an attacker who sprays one password across many usernames -
+      // every guess lands in a fresh bucket. The looser IP-only limiter is
+      // what covers that, so both are consulted on every attempt.
+      it('returns 429 without attempting a login when the IP limiter is tripped', async () => {
+        limiter.ipIsLimited.mockReturnValue(true)
+
+        const res = await app.request(
+          '/signin',
+          form({ username: 'alice', password: 'pw' })
+        )
+
+        expect(res.status).toBe(429)
+        expect(auth.login).not.toHaveBeenCalled()
+      })
+
+      it('keys the IP limiter on the address alone, not the username', async () => {
+        auth.login.mockResolvedValue({ id: 'user-1' })
+
+        await app.request('/signin', form({ username: 'alice', password: 'p' }))
+
+        expect(limiter.ipIsLimited).toHaveBeenCalledWith('ip')
+      })
+
+      it('counts a wrong-credentials failure against both limiters', async () => {
+        auth.login.mockRejectedValue(new InvalidCredentialsError())
+
+        await app.request('/signin', form({ username: 'alice', password: 'x' }))
+
+        expect(limiter.hit).toHaveBeenCalledWith('ip:alice')
+        expect(limiter.ipHit).toHaveBeenCalledWith('ip')
+      })
+
+      it('does not clear the IP limiter on a successful sign-in', async () => {
+        // Deliberate asymmetry with signinLimiter.reset above: an attacker who
+        // owns one valid account could otherwise wipe their spray budget at
+        // will by signing into it between rounds.
+        auth.login.mockResolvedValue({ id: 'user-1' })
+
+        await app.request('/signin', form({ username: 'alice', password: 'p' }))
+
+        expect(limiter.reset).toHaveBeenCalledWith('ip:alice')
+        expect(limiter.ipReset).not.toHaveBeenCalled()
+      })
+
+      it.each([
+        ['validation error', () => new ValidationError({ username: ['bad'] })],
+        ['unexpected error', () => new Error('boom')],
+      ])('does not count a %s against the IP limiter', async (_label, make) => {
+        auth.login.mockRejectedValue(make())
+
+        await app.request('/signin', form({ username: 'alice', password: 'x' }))
+
+        expect(limiter.ipHit).not.toHaveBeenCalled()
       })
     })
 

--- a/apps/hono/src/routes/auth.tsx
+++ b/apps/hono/src/routes/auth.tsx
@@ -13,7 +13,9 @@ import { logger, safeError } from '../lib/logger.js'
 import { getSessionManager } from '../middleware/session'
 import {
   signinLimiter,
+  signinIpLimiter,
   signinRateLimitKey,
+  getClientIp,
   signupLimiter,
   forgotPasswordLimiter,
   rateLimitByIp,
@@ -62,8 +64,16 @@ auth.post('/signin', async (c) => {
   const keepSignedIn = formData.keepSignedIn === 'true'
   const redirectTo = formData.redirectTo as string | undefined
 
+  // Two keys, two attacks. The IP:username key stops guessing at one account;
+  // the IP-only key stops one address spraying a password across many
+  // usernames, which the first never sees because every guess lands in a fresh
+  // bucket.
   const rateLimitKey = signinRateLimitKey(c, username || '')
-  if (signinLimiter.isLimited(rateLimitKey)) {
+  const ipKey = getClientIp(c)
+  if (
+    signinLimiter.isLimited(rateLimitKey) ||
+    signinIpLimiter.isLimited(ipKey)
+  ) {
     return c.html(
       <SignInPage
         errors={{
@@ -81,6 +91,9 @@ auth.post('/signin', async (c) => {
   try {
     const user = await authService.login({ username, password })
 
+    // Only the per-account counter is cleared. Clearing the IP counter too
+    // would let an attacker who owns one valid account wipe their spray budget
+    // by signing into it between rounds.
     signinLimiter.reset(rateLimitKey)
 
     // Create session
@@ -106,6 +119,7 @@ auth.post('/signin', async (c) => {
       errors = error.fields
     } else if (error instanceof InvalidCredentialsError) {
       signinLimiter.hit(rateLimitKey)
+      signinIpLimiter.hit(ipKey)
       errors = { _form: ['Invalid username or password'] }
     } else if (error instanceof EmailVerificationRequiredError) {
       errors = { _form: [error.message] }

--- a/apps/hono/src/routes/private.test.tsx
+++ b/apps/hono/src/routes/private.test.tsx
@@ -32,6 +32,24 @@ import {
 const svc = createServiceMocks()
 const session = createSessionMocks()
 
+const unlockLimiter = {
+  isLimited: vi.fn(),
+  hit: vi.fn(),
+  reset: vi.fn(),
+}
+
+// The RateLimiter class has its own unit tests; what matters here is that the
+// unlock route consults it and honours the answer, so the seam is driven
+// directly - same approach as auth.test.tsx.
+vi.mock('../middleware/rate-limit', () => ({
+  privateUnlockLimiter: {
+    isLimited: (...a: unknown[]): boolean =>
+      unlockLimiter.isLimited(...a) as boolean,
+    hit: (...a: unknown[]): unknown => unlockLimiter.hit(...a) as unknown,
+    reset: (...a: unknown[]): unknown => unlockLimiter.reset(...a) as unknown,
+  },
+}))
+
 vi.mock('../lib/services', () => ({
   authService: {
     login: (...a: unknown[]) => svc.login(...a) as unknown,
@@ -70,6 +88,7 @@ describe('private routes', () => {
     session.authUser.mockReturnValue(testUser)
     session.getFlash.mockReturnValue(null)
     session.isPrivateUnlocked.mockReturnValue(true)
+    unlockLimiter.isLimited.mockReturnValue(false)
     svc.getUserTags.mockResolvedValue([makeTag()])
     svc.getUserPinsWithPagination.mockResolvedValue({
       pins: [makePin({ isPrivate: true })],
@@ -187,6 +206,50 @@ describe('private routes', () => {
       expect(res.status).toBe(200)
       expect(await res.text()).toContain('Invalid password')
       expect(session.unlockPrivateMode).not.toHaveBeenCalled()
+    })
+
+    // Unlock checks the account password on every POST, so without a limit it
+    // is an unbounded password-guessing oracle for anyone holding the session
+    // cookie. Keyed on the user id, not the IP: the attacker already has the
+    // session, so the address proves nothing and rotating it must not help.
+    describe('rate limiting', () => {
+      it('returns 429 without checking the password when limited', async () => {
+        unlockLimiter.isLimited.mockReturnValue(true)
+
+        const res = await app.request(
+          '/private/unlock',
+          formBody({ password: 'guess' })
+        )
+
+        expect(res.status).toBe(429)
+        expect(svc.login).not.toHaveBeenCalled()
+        expect(session.unlockPrivateMode).not.toHaveBeenCalled()
+      })
+
+      it('keys the limiter on the user id', async () => {
+        svc.login.mockResolvedValue(testUser)
+
+        await app.request('/private/unlock', formBody({ password: 'p' }))
+
+        expect(unlockLimiter.isLimited).toHaveBeenCalledWith(testUser.id)
+      })
+
+      it('counts a wrong password against the limiter', async () => {
+        svc.login.mockRejectedValue(new InvalidCredentialsError())
+
+        await app.request('/private/unlock', formBody({ password: 'wrong' }))
+
+        expect(unlockLimiter.hit).toHaveBeenCalledWith(testUser.id)
+      })
+
+      it('clears the limiter on a correct password', async () => {
+        svc.login.mockResolvedValue(testUser)
+
+        await app.request('/private/unlock', formBody({ password: 'right' }))
+
+        expect(unlockLimiter.reset).toHaveBeenCalledWith(testUser.id)
+        expect(unlockLimiter.hit).not.toHaveBeenCalled()
+      })
     })
 
     it('locks and redirects to the public list', async () => {

--- a/apps/hono/src/routes/private.tsx
+++ b/apps/hono/src/routes/private.tsx
@@ -7,6 +7,7 @@ import {
   requireAuth,
 } from '../middleware/session'
 import { requirePrivateUnlock } from '../middleware/private-mode'
+import { privateUnlockLimiter } from '../middleware/rate-limit'
 import { PrivateUnlockPage } from '../views/pages/private-unlock'
 import { createPinRoutes } from './pin-routes'
 
@@ -39,8 +40,21 @@ privateRouter.post('/unlock', async (c) => {
   const password =
     typeof formData.password === 'string' ? formData.password : ''
 
+  // This checks the account password on every POST, so unlimited it is a
+  // password-guessing oracle for anyone who has got hold of the session.
+  if (privateUnlockLimiter.isLimited(user.id)) {
+    return c.html(
+      <PrivateUnlockPage
+        user={user}
+        error="Too many failed attempts. Please try again in 15 minutes."
+      />,
+      429
+    )
+  }
+
   try {
     await authService.login({ username: user.username, password })
+    privateUnlockLimiter.reset(user.id)
     sessionManager.unlockPrivateMode()
     return c.redirect(BASE_URL)
   } catch (error) {
@@ -48,6 +62,11 @@ privateRouter.post('/unlock', async (c) => {
       error instanceof InvalidCredentialsError ||
       error instanceof ValidationError
     ) {
+      // Only a wrong password burns an attempt. ValidationError here means an
+      // empty or malformed field, which never reached a credential check.
+      if (error instanceof InvalidCredentialsError) {
+        privateUnlockLimiter.hit(user.id)
+      }
       return c.html(<PrivateUnlockPage user={user} error="Invalid password." />)
     }
     throw error


### PR DESCRIPTION
Sign-in already had brute-force protection: 5 failures per `IP:username` in a 15-minute sliding window, counting only `InvalidCredentialsError` and resetting on success. This closes three gaps around it.

## 1. `/private/unlock` had no rate limiting at all

`routes/private.tsx` called `authService.login` with the account password on every POST, unbounded. Anyone holding a hijacked session cookie had an infinite password-guessing oracle against that account.

Now capped at 5 failures / 15 min via `privateUnlockLimiter`, keyed on **`user.id`** rather than IP — the attacker in this scenario already has the session, so the address proves nothing and rotating it must not buy a fresh budget.

## 2. Username rotation was never counted

The `IP:username` key stops guessing at one account, but never fires against one address spraying a single password across many usernames — every guess lands in a fresh bucket.

`signinIpLimiter` (20 failures / 15 min, **IP only**) now runs alongside it; either one tripping returns 429. 20 is deliberately loose so a shared office NAT or CGNAT won't trip it in normal use.

## 3. `getClientIp` collapsed header-less requests into one bucket

The `?? 'unknown'` fallback put every caller arriving without `X-Forwarded-For` into a single shared bucket, so one attacker could exhaust it and 429 every other such user. It now falls back to the socket peer address via `getConnInfo`, which is always available under `@hono/node-server`. Taking the *last* XFF entry is unchanged — that's correct behind a single trusted proxy whether it appends or overwrites.

## Deliberate asymmetries

Both are commented at the point of use:

- **Success resets the per-account counter but not the IP counter.** Otherwise an attacker who owns one valid account could wipe their spray budget by signing into it between rounds.
- **Only `InvalidCredentialsError` burns an attempt.** Counting validation or infrastructure failures would let a broken dependency lock users out.

## Not addressed

**Many IPs against a single account.** Closing it needs a username-only limiter, which hands anyone a way to lock a specific real user out of their own account by failing logins on their behalf. That trade belongs with the account-lockout / email-notification design, not here.

**Limiter state is still an in-memory `Map`**, so deploys reset budgets and this doesn't work across multiple instances. Out of scope by decision; noting it as the ceiling on what this buys.

## Testing

TDD throughout — each of the three pieces had a confirmed red (failing on the assertion, not an import error) before implementation.

- `middleware/rate-limit.test.ts` — socket-address fallback, and `unknown` only when even that is unavailable
- `routes/auth.test.tsx` — IP limiter tripping returns 429 without calling login, keys on address alone, both limiters hit on wrong credentials, IP counter *not* reset on success, neither counter hit on validation/unexpected errors
- `routes/private.test.tsx` — new `rate limiting` block covering all four behaviors on unlock

`pnpm quality` passes (exit 0): typecheck, lint, 844 tests across all 8 workspaces including `@pinsquirrel/database` against live MySQL, format, and audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)